### PR TITLE
Fix issue where terminal output wasn't properly synchronized with the terminal commander

### DIFF
--- a/src/Terminal/Terminal.tsx
+++ b/src/Terminal/Terminal.tsx
@@ -113,20 +113,15 @@ const TerminalComponent = ({
         [modemPort, handleModemResponse]
     );
 
-    const onData = useCallback(
-        (data: string) => {
-            const str = data.replace('\r', EOL);
-
-            output = `${output}${str}`;
-            let i: number;
-            // eslint-disable-next-line no-cond-assign
-            while ((i = output.indexOf(EOL)) > -1) {
-                handleOutput(output.slice(0, i + EOL.length));
-                output = output.slice(i + EOL.length);
-            }
-        },
-        [handleOutput]
-    );
+    const onData = useCallback(() => {
+        output = nrfTerminalCommander.output;
+        let i: number;
+        // eslint-disable-next-line no-cond-assign
+        while ((i = output.indexOf(EOL)) > -1) {
+            handleOutput(output.slice(0, i + EOL.length));
+            output = output.slice(i + EOL.length);
+        }
+    }, [handleOutput]);
 
     const terminalOptions = {
         convertEol: true,


### PR DESCRIPTION
Currently the output registered in the terminal is not properly updated, e.g. if the user types `a` then backspace and now types `help`, the `a` is never properly removed from the output, so the resulting command will be `ahelp`. This PR should ensure that the output is properly updated.