### PR TITLE
Upgrade needed engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Nordic Semiconductor ASA",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {
-    "nrfconnect": "^3.6.0"
+    "nrfconnect": "^3.7.0"
   },
   "main": "dist/bundle.js",
   "files": [


### PR DESCRIPTION
The GA code in this project now depends on launcher having at least
version 3.7 (which is not released yet but already in master). So far
using launcher 3.6 does not crash the app, it just leads to an error
in the console but it is still more sensible to mark that this app
needs 3.7.