### PR TITLE
Register output handler to sync with commander

### DIFF
--- a/src/Terminal/Terminal.tsx
+++ b/src/Terminal/Terminal.tsx
@@ -69,6 +69,7 @@ const TerminalComponent = ({
 }) => {
     const xtermRef = useRef<XTerm | null>(null);
     const userInput = useRef('');
+    const previousUserInput = useRef('');
 
     const modem = useSelector(getModem);
     const fitAddon = useFitAddon(height, width);
@@ -129,12 +130,22 @@ const TerminalComponent = ({
         [modem, writeln]
     );
 
+    const outputHandler = (output: string) => {
+        previousUserInput.current = userInput.current;
+        userInput.current = output;
+    };
+
+    useEffect(() => {
+        nrfTerminalCommander.registerOutputListener(outputHandler);
+    }, []);
+
     const onKeyPress = useCallback(
         key => {
             const pressedReturn = key.charCodeAt(0) === 13;
-            userInput.current = pressedReturn
-                ? userInput.current + EOL
-                : nrfTerminalCommander.output;
+
+            if (pressedReturn) {
+                userInput.current = previousUserInput.current + EOL;
+            }
 
             const { inputLines, remainder } = split(userInput.current);
             inputLines.forEach(handleUserInputLine);


### PR DESCRIPTION
Currently the terminal component is unaware that its content has been updated if the history addon is used. So instead of waiting for the `onData` callback to trigger, we register an output listener that fires anytime the output changes. We can then properly keep the output synced between terminal and commander.