### PR TITLE
Remove the currently unsupported panes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,10 +39,8 @@ import { App } from 'pc-nrfconnect-shared';
 
 import Dashboard from './Dashboard/Dashboard';
 import DeviceSelector from './DeviceSelector';
-import GPS from './GPS/GPS';
 import reducer from './reducer';
 import SidePanel from './SidePanel/SidePanel';
-import Terminal from './Terminal/Terminal';
 
 import './index.scss';
 
@@ -52,10 +50,6 @@ export default () => (
         appReducer={reducer}
         deviceSelect={<DeviceSelector />}
         sidePanel={<SidePanel />}
-        panes={[
-            { name: 'Dashboard', Main: Dashboard },
-            { name: 'Terminal', Main: Terminal },
-            { name: 'GPS', Main: GPS },
-        ]}
+        panes={[{ name: 'Dashboard', Main: Dashboard }]}
     />
 );


### PR DESCRIPTION
Implements https://trello.com/c/VbqESuQ8/33-hide-terminal-and-gps-pane

If a user previously had the GPS pane open when closing the app and opens it again now with the terminal and GPS pane removed the app will crash. This is fixed by https://github.com/NordicSemiconductor/pc-nrfconnect-shared/pull/146. But since this app is not released yet, I do not deem this to be critical anyhow.