### PR TITLE
Remove wrong entry in tsconfig

### DIFF
--- a/src/utils/testUtils.tsx
+++ b/src/utils/testUtils.tsx
@@ -64,7 +64,7 @@ jest.mock('pc-nrfconnect-shared', () => {
         getAppDir: () => '/mocked/data/dir',
         getAppDataDir: () => '/mocked/data/dir',
         getPersistentStore: jest.fn().mockImplementation(() => ({
-            get: (_, defaultVal: unknown) => defaultVal,
+            get: (_: unknown, defaultVal: unknown) => defaultVal,
             set: jest.fn(),
         })),
     };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,3 @@
 {
-    "extends": "./node_modules/pc-nrfconnect-shared/config/tsconfig.json",
-    "include": ["./src/svg.d.ts"]
+    "extends": "./node_modules/pc-nrfconnect-shared/config/tsconfig.json"
 }


### PR DESCRIPTION
Including `./src/svg.d.ts` is not necessary and in my VS code actually
leads to an error being displayed when importing an svg, e.g. currently
in DatabaseFileOverride.tsx:44.

No idea why the linter now complains about the missing type in
`testUtils.tsx`. Just fixing it now also to make the build succeed.