### PR TITLE
Update Changelog and version

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,12 @@
+## 0.0.3
+-
+
 ## 0.0.2
 - Show Wireshark button on all platforms (not only on Windows, but also
   on Linux and macOS).
+- Enable using pure JSON files as Trace DBs (previously only .tar.gz were supported)
+- Decode not only IP but also other packet types like LTE, AT and NAS.
+- Use a preview of the 1.3.0 public trace DB (still only for internal use).
 
 ## 0.0.1
 - Initial internal release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-cellularmonitor",
-  "version": "0.0.2",
+  "version": "0.0.3-pre1",
   "description": "Swiss army knife tool for nRF91 devices",
   "displayName": "Cellular Monitor",
   "repository": {


### PR DESCRIPTION
There was an internal release of 0.0.2 which I am just not able to merge correctly back into master because 0.5.0 of `nrf-monitor-lib-js` was replaces. But at least the version number should be updated and the missing changelog entries added which is reflected in this PR.