### PR TITLE
Bump version

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+## 0.0.4
+-
+
 ## 0.0.3
 - Fixed: The file size while creating a pcap tracefile is now also reported
   correctly.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-cellularmonitor",
-  "version": "0.0.3-pre1",
+  "version": "0.0.4-pre1",
   "description": "Swiss army knife tool for nRF91 devices",
   "displayName": "Cellular Monitor",
   "repository": {


### PR DESCRIPTION
Bump version, because I released 415159b3503b3abca72d0c4f8548c2d3c9afbf0e as 0.0.3-pre1 internally.