### PR TITLE
Fix downloading nrf-monitor-lib from GitHub

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15903,9 +15903,9 @@
       }
     },
     "prebuild-install": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.1.tgz",
-      "integrity": "sha512-M+cKwofFlHa5VpTWub7GLg5RLcunYIcLqtY5pKcls/u7xaAb8FrXZ520qY8rkpYy5xw90tYCyMO0MP5ggzR3Sw==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
+      "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",
@@ -15914,7 +15914,6 @@
         "mkdirp-classic": "^0.5.3",
         "napi-build-utils": "^1.0.1",
         "node-abi": "^2.21.0",
-        "noop-logger": "^0.1.1",
         "npmlog": "^4.0.1",
         "pump": "^3.0.0",
         "rc": "^1.2.7",


### PR DESCRIPTION
Before 6.1.4 prebuild-install used the deprecated authentication via query parameters, which is currently turned off during a brownout and soon will be removed completely. https://github.blog/changelog/2021-04-19-sunsetting-api-authentication-via-query-parameters-and-the-oauth-applications-api/

Through

    npm install prebuild-install@latest --no-save --package-lock-only

this upgraded the prebuild-install to 6.1.4 which fixes this problem.