### PR TITLE
Fix: Make sink file names more reliable

### DIFF
--- a/src/features/tracing/formats.ts
+++ b/src/features/tracing/formats.ts
@@ -29,4 +29,5 @@ export type SourceFormat =
     | {
           type: 'device';
           port: string;
+          startTime: Date;
       };

--- a/src/features/tracing/nrfml.ts
+++ b/src/features/tracing/nrfml.ts
@@ -97,7 +97,11 @@ export const startTrace =
             logger.error('Select serial port to start tracing');
             return;
         }
-        const source: SourceFormat = { type: 'device', port };
+        const source: SourceFormat = {
+            type: 'device',
+            port,
+            startTime: new Date(),
+        };
 
         sinks.forEach(format => {
             usageData.sendUsageData(sinkEvent(format));

--- a/src/features/tracing/sinkFile.test.ts
+++ b/src/features/tracing/sinkFile.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import createSinkFile from './sinkFile';
+
+jest.mock('pc-nrfconnect-shared', () => ({
+    ...jest.requireActual('pc-nrfconnect-shared'),
+    getAppDataDir: () => 'data/dir',
+}));
+
+describe('sink file names', () => {
+    it('is for file sources based on the source file name', () => {
+        const sinkFile = createSinkFile(
+            { type: 'file', path: 'some/file.bin' },
+            'pcap'
+        );
+
+        expect(sinkFile).toBe('some/file.pcapng');
+    });
+
+    it('is for device sources based on the start time, resilient to passing time', done => {
+        const startTime = new Date('2021-12-24T01:02:03.456Z');
+
+        const sinkFile = createSinkFile(
+            { type: 'device', port: 'a port', startTime },
+            'raw'
+        );
+        expect(sinkFile).toBe(
+            `data/dir/trace-${startTime.toISOString().replace(/:/g, '-')}.bin`
+        );
+
+        setTimeout(() => {
+            const sinkFileAfter10Milliseconds = createSinkFile(
+                { type: 'device', port: 'a port', startTime },
+                'raw'
+            );
+            expect(sinkFileAfter10Milliseconds).toBe(
+                `data/dir/trace-${startTime
+                    .toISOString()
+                    .replace(/:/g, '-')}.bin`
+            );
+            done();
+        }, 10);
+    });
+});

--- a/src/features/tracing/sinkFile.ts
+++ b/src/features/tracing/sinkFile.ts
@@ -29,7 +29,9 @@ const extensionlessFilePath = (source: SourceFormat) => {
         return path.join(directory, basename);
     }
 
-    const filename = `trace-${new Date().toISOString().replace(/:/g, '-')}`;
+    const filename = `trace-${source.startTime
+        .toISOString()
+        .replace(/:/g, '-')}`;
     return path.join(getAppDataDir(), filename);
 };
 


### PR DESCRIPTION
When creating a tracing file, the file name is based on the current
time, but that time was evaluated multiple times, which could lead to
multiple bugs:
- When creating a raw and pcap trace, they could have different names.
- The progress of the trace was sometimes not displayed because the app
  expected a slightly different file name.