### PR TITLE
Stop tracing when closing live stream.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+- Stop trace when closing wireshark during live trace only.
+
 ## 0.3.0
 ### Added
 - Extract data for the

--- a/src/features/tracing/__mocks__/@nordicsemiconductor/nrf-monitor-lib-js.ts
+++ b/src/features/tracing/__mocks__/@nordicsemiconductor/nrf-monitor-lib-js.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-export default { start: jest.fn().mockReturnValue(1), stop: jest.fn() };
+export default {
+    start: jest.fn().mockReturnValue(1),
+    stop: jest.fn(),
+};
 
 const getPluginsDir = jest.fn().mockReturnValue('mocked_plugin_dir_path');
 

--- a/src/features/tracing/nrfml.ts
+++ b/src/features/tracing/nrfml.ts
@@ -155,18 +155,18 @@ export const startTrace =
         };
         dispatch(resetPowerEstimationParams());
 
-        sinks.forEach(format => {
-            usageData.sendUsageData(sinkEvent(format));
-        });
-
         const isDetectingTraceDb =
             getManualDbFilePath(state) == null &&
             !(sinks.length === 1 && sinks[0] === 'raw'); // if we originally only do RAW trace, we do not show dialog
 
         const selectedTsharkPath = getTsharkPath(getState());
-        if (findTshark(selectedTsharkPath)) {
+        if (findTshark(selectedTsharkPath) && !sinks.includes('opp')) {
             sinks.push('opp');
         }
+
+        sinks.forEach(format => {
+            usageData.sendUsageData(sinkEvent(format));
+        });
 
         const taskId = nrfml.start(
             nrfmlConfig(state, source, sinks),
@@ -182,7 +182,11 @@ export const startTrace =
                     logger.info('Finished tracefile');
                 }
                 // stop tracing if Completed callback is called and we are only doing live tracing
-                if (sinks.length === 1 && sinks[0] === 'live') {
+                if (
+                    sinks.length === 2 &&
+                    sinks.includes('live') &&
+                    sinks.includes('opp')
+                ) {
                     dispatch(stopTrace(taskId));
                 }
             },

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -15,9 +15,7 @@ import thunk from 'redux-thunk';
 import appReducer from '../appReducer';
 import { TDispatch } from '../thunk';
 
-export const mockedNrfmlStart = nrfml.start as jest.MockedFunction<
-    typeof nrfml.start
->;
+const mockedNrfmlStart = nrfml.start as jest.MockedFunction<typeof nrfml.start>;
 
 export const getNrfmlCallbacks = () => {
     return new Promise<{


### PR DESCRIPTION
Close tracing when only live tracing is enabled and wireshark is closed.

Also prevents adding multiple opp-sinks on consecutive rounds of tracing.

![image](https://user-images.githubusercontent.com/1006193/154271813-be4607f8-c2db-4998-9ed6-ca8d15514d6a.png)
