### PR TITLE
Remove outdated module reference

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -11,9 +11,12 @@
         "\\.(css|scss)$": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/emptyMock.js",
         "packageJson$": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/packageJsonMock.js",
         "pc-ble-driver-js": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/bleDriverMock.js",
-        "pc-nrfjprog-js|nrf-device-lister|nrf-device-setup|usb": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/emptyMock.js",
+        "pc-nrfjprog-js|nrf-device-setup|usb": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/emptyMock.js",
         "^electron$": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/electronMock.js",
-        "^electron-store$": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/electronStoreMock.js"
+        "^electron-store$": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/electronStoreMock.js",
+        "^react-ga$": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/gaMock.js",
+        "@nordicsemiconductor/nrf-device-lib-js": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/deviceLibMock.js",
+        "@electron/remote": "<rootDir>/node_modules/pc-nrfconnect-shared/mocks/remoteMock.js"
     },
     "transform": {
         "^.+\\.[jt]sx?$": [


### PR DESCRIPTION
Removed the reference to the outdated `nrfconnect/core` module from the jest config. 

Also explained that and why we copy the jest config here and update the copy.