### PR TITLE
Fix some Linux crashes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2005,9 +2005,9 @@
             }
         },
         "@nordicsemiconductor/nrf-monitor-lib-js": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/nrf-monitor-lib-js/-/nrf-monitor-lib-js-0.7.2.tgz",
-            "integrity": "sha512-n3T9m/26zZwUEarEBdQmmEMlbbrQtPSP3fVAHyvgA5ithTQM2l0b8SKEwN2yFNxQRJZt/+Bz2Fgc78Uc3dteLA=="
+            "version": "0.7.3",
+            "resolved": "https://npm.nordicsemi.no/@nordicsemiconductor%2fnrf-monitor-lib-js/-/nrf-monitor-lib-js-0.7.3.tgz",
+            "integrity": "sha512-S9PgbSImgmO8gDawfJFeu0bqhZO1gWwjgR+zG68TdxISLuUlsqc4g0xA0I58L6QN/sEEH3DTYK7AMrNkcEXMKQ=="
         },
         "@plotly/d3": {
             "version": "3.8.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "xterm-for-react": "^1.0.4"
     },
     "dependencies": {
-        "@nordicsemiconductor/nrf-monitor-lib-js": "0.7.2",
+        "@nordicsemiconductor/nrf-monitor-lib-js": "0.7.3",
         "npm": "^6.14.13"
     },
     "bundledDependencies": [


### PR DESCRIPTION
Fixed in `nrf-monitor-lib@0.9.6`, which is brought in through `nrf-monitor-lib-js@0.7.3`.