### PR TITLE
Feat/convert psm values

### DIFF
--- a/src/features/powerEstimation/powerEstimationSlice.ts
+++ b/src/features/powerEstimation/powerEstimationSlice.ts
@@ -39,26 +39,21 @@ const powerEstimationSlice = createSlice({
         setData: (state, action: PayloadAction<OnlinePowerEstimatorParams>) => {
             const { config_lte_psm_req_rptau, config_lte_psm_req_rat } =
                 action.payload;
-            const newTAUValue = config_lte_psm_req_rptau
-                ? parseTAUByteToSeconds(
-                      config_lte_psm_req_rptau,
-                      TAU_TYPES.SLEEP_INTERVAL
-                  )
-                : state.data?.config_lte_psm_req_rptau;
-            const newActiveTimer = config_lte_psm_req_rat
-                ? parseTAUByteToSeconds(
-                      config_lte_psm_req_rat,
-                      TAU_TYPES.ACTIVE_TIMER
-                  )
-                : state.data?.config_lte_psm_req_rat;
-
-            console.log(`newActiveTimer is now set to: ${newActiveTimer}`);
 
             state.data = action.payload;
-            if (newTAUValue != null) {
+
+            if (config_lte_psm_req_rptau != null) {
+                const newTAUValue = parseTAUByteToSeconds(
+                    config_lte_psm_req_rptau,
+                    TAU_TYPES.SLEEP_INTERVAL
+                );
                 state.data.psm_int = `${newTAUValue}`;
             }
-            if (newActiveTimer != null) {
+            if (config_lte_psm_req_rat != null) {
+                const newActiveTimer = parseTAUByteToSeconds(
+                    config_lte_psm_req_rat,
+                    TAU_TYPES.ACTIVE_TIMER
+                );
                 state.data.idrx_len = `${newActiveTimer}`;
             }
         },


### PR DESCRIPTION
For now the Online Power Profiler parameters `psm_int` and `idrx_len` are set by using default values rather than utilize the trace data. These two parameters seems to be what ultimately sets the Power Saving Mode (PSM) values in the Online Power Profiler. This PR introduces a temporary fix by parsing the PSM values that the device is requesting from the network, which will allow the Online Power Profiler to display more relevant estimation data to the customer. 

**The trace data where the DUT request the PSM values**

![image](https://user-images.githubusercontent.com/34618612/189594538-77bc1058-a1c4-4e5b-b705-4a42c1a2c182.png)

**should correspond the the data in the Power Estimation tab**
![image](https://user-images.githubusercontent.com/34618612/189594904-4198b0fc-407f-416d-8e8d-10d4287bc7a2.png)


