### PR TITLE
fix: handle scales being undefined

### DIFF
--- a/src/components/EventChart/Chart/panZoomPlugin.ts
+++ b/src/components/EventChart/Chart/panZoomPlugin.ts
@@ -484,11 +484,8 @@ export default {
         // This clears the scales and leads to visual glitches
         if (chart.data.datasets[0].data.length <= 0) return;
 
-        if (
-            (chart.scales.x.options as CartesianScaleOptions).min ===
-                undefined ||
-            (chart.scales.x.options as CartesianScaleOptions).max === undefined
-        ) {
+        const options = chart.scales.x.options as CartesianScaleOptions;
+        if (options.min === undefined || options.max === undefined) {
             const {
                 data,
                 options: {
@@ -517,6 +514,7 @@ export default {
 
                 if (newFirstDataIndex === -1) newRange = { ...currentRange };
                 else {
+                    // Use modulo to avoid snapping data points into default position.
                     const min = newFirstDataIndex + (currentRange.min % 1);
                     newRange = {
                         min,


### PR DESCRIPTION
When the trace event filter is changed it would lead to visual glitches. This was due to chartjs resetting the scales values. Now it is handled and additionally retains a reference of the previous position.