### PR TITLE
feat(logging): log versions of nrfml as info

### DIFF
--- a/src/utils/logLibVersions.ts
+++ b/src/utils/logLibVersions.ts
@@ -19,18 +19,14 @@ const version = (module: ModuleVersion) => {
     }
 };
 
-const describe = (module: ModuleVersion) =>
-    `${module.module_name} ${version(module)}`;
-
 export default async () => {
     const { modules } = await nrfml.apiVersion();
 
-    if (modules.length > 0) {
-        logger.debug('Lib module versions:');
-        modules.forEach(module => logger.debug(`- ${describe(module)}`));
-    }
-
-    logger.debug(
-        `- ${nrfMonitorLibJsPackageJson.name} ${nrfMonitorLibJsPackageJson.version}`
+    logger.info(
+        `Using nrf-monitor-lib-js version  ${nrfMonitorLibJsPackageJson.version}`
     );
+    if (modules.length > 0) {
+        // In this case, we always expect to only have one module, namely nrfml
+        logger.info(`Using nrf-monitor-lib version ${version(modules[0])}`);
+    }
 };


### PR DESCRIPTION
With `logger.debug` versions are only displayed in the developer console, while the `logger.info` will display it in the app's log.

In addition, this commit changes the format to be consistent with the versions we currently log from pc-nrfconnect-shared.

Example:

![image](https://user-images.githubusercontent.com/34618612/231482877-daf38852-bbf9-4a6d-838d-9248e39a5463.png)
