### PR TITLE
Move @mdi icons dependencies to dev-dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
     "name": "pc-nrfconnect-cellularmonitor",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pc-nrfconnect-cellularmonitor",
-            "version": "0.4.2",
+            "version": "0.4.3",
             "bundleDependencies": [
                 "@nordicsemiconductor/nrf-monitor-lib-js"
             ],
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
-                "@mdi/js": "^7.2.96",
-                "@mdi/react": "^1.6.1",
                 "@nordicsemiconductor/nrf-monitor-lib-js": "^0.8.0-pre2"
             },
             "devDependencies": {
+                "@mdi/js": "^7.2.96",
+                "@mdi/react": "^1.6.1",
                 "@types/redux-mock-store": "^1.0.2",
                 "chart.js": "^4.1.2",
                 "check-disk-space": "^2.1.0",
@@ -2050,12 +2050,14 @@
         "node_modules/@mdi/js": {
             "version": "7.2.96",
             "resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.2.96.tgz",
-            "integrity": "sha512-paR9M9ZT7rKbh2boksNUynuSZMHhqRYnEZOm/KrZTjQ4/FzyhjLHuvw/8XYzP+E7fS4+/Ms/82EN1pl/OFsiIA=="
+            "integrity": "sha512-paR9M9ZT7rKbh2boksNUynuSZMHhqRYnEZOm/KrZTjQ4/FzyhjLHuvw/8XYzP+E7fS4+/Ms/82EN1pl/OFsiIA==",
+            "dev": true
         },
         "node_modules/@mdi/react": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/@mdi/react/-/react-1.6.1.tgz",
             "integrity": "sha512-4qZeDcluDFGFTWkHs86VOlHkm6gnKaMql13/gpIcUQ8kzxHgpj31NuCkD8abECVfbULJ3shc7Yt4HJ6Wu6SN4w==",
+            "dev": true,
             "dependencies": {
                 "prop-types": "^15.7.2"
             }
@@ -10901,6 +10903,7 @@
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/js-yaml": {
@@ -11360,6 +11363,7 @@
         },
         "node_modules/loose-envify": {
             "version": "1.4.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
@@ -12728,6 +12732,7 @@
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -13791,6 +13796,7 @@
         },
         "node_modules/prop-types": {
             "version": "15.8.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.4.0",
@@ -13827,6 +13833,7 @@
         },
         "node_modules/prop-types/node_modules/react-is": {
             "version": "16.13.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/protobufjs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-cellularmonitor",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "description": "EXPERIMENTAL: Capture and convert nRF91 modem traces",
     "displayName": "Cellular Monitor",
     "homepage": "https://github.com/NordicPlayground/pc-nrfconnect-cellularmonitor",
@@ -44,11 +44,11 @@
         "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v31",
         "pretty-bytes": "^5.6.0",
         "react-chartjs-2": "^5.2.0",
-        "redux-mock-store": "^1.5.4"
+        "redux-mock-store": "^1.5.4",
+        "@mdi/js": "^7.2.96",
+        "@mdi/react": "^1.6.1"
     },
     "dependencies": {
-        "@mdi/js": "^7.2.96",
-        "@mdi/react": "^1.6.1",
         "@nordicsemiconductor/nrf-monitor-lib-js": "^0.8.0-pre2"
     },
     "eslintConfig": {


### PR DESCRIPTION
The dependencies need to be registered as external if they are to be dependencies, but are not required to be registered as external if they are dev-dependencies.