### PR TITLE
fix: setDashboardState persisted state from future

### DIFF
--- a/src/features/tracingEvents/dashboardSlice.ts
+++ b/src/features/tracingEvents/dashboardSlice.ts
@@ -17,10 +17,7 @@ const dashboardSlice = createSlice({
         resetDashboardState: () => ({
             ...initialState(),
         }),
-        setDashboardState: (state, action: PayloadAction<State>) => ({
-            ...state,
-            ...action.payload,
-        }),
+        setDashboardState: (_, action: PayloadAction<State>) => action.payload,
 
         setRRCState: (state, action: PayloadAction<RRCState>) => {
             state.rrcState = action.payload;


### PR DESCRIPTION
When paning the event chart backwards in time, we should not persist the events that has happened in the "future". If a field was set to undefined, but was defined before, it would not be overwritten.

Since we always run through all the events before setting the new dashboard state, there's no reason to also deconstruct the old state. This commit only sets the new state based on the reduced new state.