### PR TITLE
feat: Show value 'Not set' on TX Reduction

### DIFF
--- a/src/features/dashboard/Cards/Device.tsx
+++ b/src/features/dashboard/Cards/Device.tsx
@@ -137,6 +137,11 @@ const formatMode = (mode?: Mode) => {
     if (mode === undefined) {
         return 'Unknown';
     }
+
+    if (mode === 'Not set') {
+        return mode;
+    }
+
     if (typeof mode === 'number') {
         return `Maximum power reduced ${txPowerReductionToDecibel(
             mode


### PR DESCRIPTION
Instead of showing 'Unknown' when we've read XEMPR TX Reduction, we can show that we've read the values are not set.