### PR TITLE
feat: Improve operator name formatting

### DIFF
--- a/src/features/dashboard/Cards/Sim.tsx
+++ b/src/features/dashboard/Cards/Sim.tsx
@@ -17,6 +17,7 @@ export default () => {
         uiccInitialisedErrorCause,
         imsi,
         operatorFullName,
+        operatorShortName,
         pinCodeStatus: pin,
         pinRetries: {
             SIM_PIN: remainingPIN,
@@ -34,7 +35,7 @@ export default () => {
             value: imsi ?? 'Unknown',
         },
         OPERATOR: {
-            value: operatorFullName ?? 'Unknown',
+            value: parseOperator(operatorFullName, operatorShortName),
         },
         ICCID: {
             value: iccid ?? 'Unknown',
@@ -73,4 +74,14 @@ const uiccStatus = (status?: boolean) => {
 
     // string status according to documentation on infocenter
     return status ? 'Initialization OK' : 'Not Initialized';
+};
+
+const parseOperator = (
+    operatorFullName?: string,
+    operatorShortName?: string
+) => {
+    if (operatorFullName === '' && operatorShortName === '') {
+        return 'Not Available';
+    }
+    return operatorFullName ?? operatorShortName ?? 'Unknown';
 };


### PR DESCRIPTION
Observed that operator may be an empty string. When this happens the field is empty. In this case, the field should not be empty, and it should not be 'Unknown'.

This commit checks if both operator variables are empty strings, and if they are the operator field shows 'Not Available'.