### PR TITLE
Use nrfdl SerialPort comName for windows compatibility

### DIFF
--- a/src/features/terminal/uartSerialPort.ts
+++ b/src/features/terminal/uartSerialPort.ts
@@ -90,10 +90,10 @@ export const autoSetUartSerialPort =
     (device: Device): TAction =>
     async dispatch => {
         const port = device.serialPorts?.at(0);
-        if (port && port.path) {
+        if (port && port.comName) {
             const uartSerialPort = await connectToSerialPort(
                 dispatch,
-                port.path
+                port.comName
             );
 
             if (uartSerialPort) {


### PR DESCRIPTION
SerialPort `path` seems to work fine on linux, however on Windows `comName` must be used. This commit changes the use to comName, as that should work on all supported platforms.