### PR TITLE
feat: option to enable/disable tshark sink

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@
 -   Power Saving Mode values are now shown as decimal time units, days, hours,
     minutes, seconds, with the bit mask shown in parentheses. Example, REQUESTED
     PERIODIC TAU: 1 hour (00100001)
+-   Option to enable/disable tshark for more detail in the dashboard view. This
+    option was always enabled before, but is now disabled by default, because it
+    adds more delay. This option does not affect the content of the trace file.
 
 ### Changed
 

--- a/src/components/SidePanel/FileActions.tsx
+++ b/src/components/SidePanel/FileActions.tsx
@@ -10,6 +10,7 @@ import { Group, selectedDevice } from 'pc-nrfconnect-shared';
 
 import { LoadTraceFile } from './LoadTraceFile';
 import TraceConverter from './Tracing/TraceConverter';
+import { AddTsharkSink } from './TsharkSink';
 
 export default () => {
     const device = useSelector(selectedDevice);
@@ -18,6 +19,7 @@ export default () => {
 
     return (
         <Group heading="FILE ACTIONS">
+            <AddTsharkSink />
             <LoadTraceFile />
             <TraceConverter />
         </Group>

--- a/src/components/SidePanel/TraceOptions.tsx
+++ b/src/components/SidePanel/TraceOptions.tsx
@@ -55,24 +55,19 @@ const TraceSettings = () => {
     return (
         <>
             {is91DK(device) && (
-                <div className="d-flex justify-content-between">
-                    Reset device on start{' '}
-                    <Toggle
-                        disabled={isTracing}
-                        isToggled={resetDevice}
-                        onToggle={dispatchToggle(setResetDevice)}
-                    />
-                </div>
-            )}
-
-            <div className="d-flex justify-content-between">
-                Refresh dashboard on start{' '}
                 <Toggle
+                    label="Reset device on start"
                     disabled={isTracing}
-                    isToggled={refreshDashboard}
-                    onToggle={dispatchToggle(setRefreshDashboard)}
+                    isToggled={resetDevice}
+                    onToggle={dispatchToggle(setResetDevice)}
                 />
-            </div>
+            )}
+            <Toggle
+                label="Refresh dashboard on start"
+                disabled={isTracing}
+                isToggled={refreshDashboard}
+                onToggle={dispatchToggle(setRefreshDashboard)}
+            />
         </>
     );
 };

--- a/src/components/SidePanel/Tracing/TraceFormatSelector.tsx
+++ b/src/components/SidePanel/Tracing/TraceFormatSelector.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../../features/tracing/traceSlice';
 import WiresharkWarning from '../../../features/wireshark/WiresharkWarning';
 import EventAction from '../../../usageDataActions';
+import { AddTsharkSink } from '../TsharkSink';
 
 export default () => {
     const selectedFormats = useSelector(getTraceFormats);
@@ -34,23 +35,19 @@ export default () => {
 
     return (
         <>
-            <div className="d-flex justify-content-between">
-                Open in Wireshark{' '}
-                <Toggle
-                    disabled={isTracing}
-                    isToggled={selectedFormats.includes('live')}
-                    onToggle={toggle('live')}
-                />
-            </div>
-
-            <div className="d-flex justify-content-between">
-                Save trace file to disk{' '}
-                <Toggle
-                    disabled={isTracing}
-                    isToggled={selectedFormats.includes('raw')}
-                    onToggle={toggle('raw')}
-                />
-            </div>
+            <Toggle
+                label="Open in Wireshark"
+                disabled={isTracing}
+                isToggled={selectedFormats.includes('live')}
+                onToggle={toggle('live')}
+            />
+            <Toggle
+                label="Save trace file to disk"
+                disabled={isTracing}
+                isToggled={selectedFormats.includes('raw')}
+                onToggle={toggle('raw')}
+            />
+            <AddTsharkSink />
 
             <WiresharkWarning />
         </>

--- a/src/components/SidePanel/TsharkSink.tsx
+++ b/src/components/SidePanel/TsharkSink.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Toggle } from 'pc-nrfconnect-shared';
+
+import {
+    getIsTracing,
+    getTraceFormats,
+    setTraceFormats,
+} from '../../features/tracing/traceSlice';
+
+export const AddTsharkSink = () => {
+    const dispatch = useDispatch();
+    const isTracing = useSelector(getIsTracing);
+    const sinks = useSelector(getTraceFormats);
+    const tsharkEnabled = sinks.includes('tshark');
+
+    const toggleTshark = () => {
+        if (tsharkEnabled) {
+            dispatch(setTraceFormats(sinks.filter(sink => sink !== 'tshark')));
+        } else {
+            dispatch(setTraceFormats([...sinks, 'tshark']));
+        }
+    };
+
+    return (
+        <Toggle
+            label="Analyze packets with tshark"
+            title="This option makes traces slower, but adds more detail in the Dashboard. No information is lost if this option is disabled."
+            isToggled={tsharkEnabled}
+            onToggle={toggleTshark}
+            disabled={isTracing}
+        />
+    );
+};

--- a/src/components/SidePanel/__tests__/TraceCollector.test.tsx
+++ b/src/components/SidePanel/__tests__/TraceCollector.test.tsx
@@ -113,10 +113,7 @@ describe('TraceCollector', () => {
             ]);
             fireEvent.click(screen.getByText('Start'));
 
-            expectNrfmlStartCalledWithSinks(
-                'nrfml-raw-file-sink',
-                'nrfml-tshark-sink'
-            );
+            expectNrfmlStartCalledWithSinks('nrfml-raw-file-sink');
         });
 
         it('should call nrfml start with selected sink configurations as arguments', () => {
@@ -128,8 +125,7 @@ describe('TraceCollector', () => {
 
             expectNrfmlStartCalledWithSinks(
                 'nrfml-raw-file-sink',
-                'nrfml-pcap-sink',
-                'nrfml-tshark-sink'
+                'nrfml-pcap-sink'
             );
         });
 
@@ -143,7 +139,6 @@ describe('TraceCollector', () => {
             expectNrfmlStartCalledWithSinks(
                 'nrfml-raw-file-sink',
                 'nrfml-pcap-sink',
-                'nrfml-tshark-sink',
                 'nrfml-wireshark-named-pipe-sink'
             );
         });

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -30,6 +30,9 @@ const store = getPersistentStore<StoreSchema>({
         '0.4.5': instance => {
             instance.set('traceFormats', ['raw', 'tshark']);
         },
+        '0.9.0': instance => {
+            instance.set('traceFormats', ['raw']);
+        },
     },
 });
 


### PR DESCRIPTION
Because the tshark is still slow to analyze packets, we want to disable it by default, but still provide an option for customers to enable it.