### PR TITLE
feat: Add visual effect to updated dashboard field

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@
 -   Option to enable/disable tshark for more detail in the dashboard view. This
     option was always enabled before, but is now disabled by default, because it
     adds more delay. This option does not affect the content of the trace file.
+-   Visual effect to dashboard fields that are updated, in order to make it
+    easier to notice when a change has been made.
 
 ### Changed
 

--- a/src/features/dashboard/Cards/DashboardCard.css
+++ b/src/features/dashboard/Cards/DashboardCard.css
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+.animated-card-entry {
+    animation: valueChanged 3s;
+}
+
+@keyframes valueChanged {
+    0% {
+        background-color: var(--color-nordic-blue);
+    }
+    100% {
+        background-color: white;
+    }
+}

--- a/src/features/dashboard/Cards/DashboardCard.tsx
+++ b/src/features/dashboard/Cards/DashboardCard.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
 import { useDispatch, useSelector } from 'react-redux';
@@ -24,6 +24,8 @@ import {
     recommendedAT,
 } from '../../tracingEvents/at/recommeneded';
 import { sendAT } from '../../tracingEvents/at/sendCommand';
+
+import './DashboardCard.css';
 
 export type DashboardCardFields = Record<string, DashboardCardField>;
 export type DashboardCardField = {
@@ -91,8 +93,25 @@ const CardEntry = ({ fieldKey, value, title }: CardEntry) => {
     const detectedAtHostLibrary = useSelector(getDetectedAtHostLibrary);
     const [keepShowing, setKeepShowing] = useState(false);
 
+    const fieldRef = useRef<HTMLDivElement>(null);
+    const oldValue = useRef<string | number | null>(null);
+
     const canSendCommand = device != null && detectedAtHostLibrary && isTracing;
     const showTooltip = (show: boolean) => setKeepShowing(show);
+
+    useEffect(() => {
+        if (
+            value !== oldValue.current &&
+            oldValue.current &&
+            fieldRef.current
+        ) {
+            fieldRef.current?.classList.remove('animated-card-entry');
+            setTimeout(() =>
+                fieldRef?.current?.classList.add('animated-card-entry')
+            );
+        }
+        oldValue.current = value;
+    }, [value]);
 
     return (
         <div
@@ -104,7 +123,10 @@ const CardEntry = ({ fieldKey, value, title }: CardEntry) => {
                 setKeepShowing(false);
             }}
         >
-            <div className="w-100 d-flex justify-content-between">
+            <div
+                ref={fieldRef}
+                className="w-100 d-flex justify-content-between"
+            >
                 <p>
                     <b>{fieldKey}</b>
                 </p>


### PR DESCRIPTION
When a change is detected in a dashboard field, the `background-color` of that field will get a strong _nordic blue_ color, and will transition into the default white color over 3 seconds. Hence, lighter blue or white color means that the change happened earlier, and a strong blue color means the update just happened.

Example:

![image](https://github.com/NordicPlayground/pc-nrfconnect-cellularmonitor/assets/34618612/47acba97-7b02-4aa9-88b2-d1a2f5e988f3)
