### PR TITLE
Update shell parser & automatically detect prompt

### DIFF
--- a/src/features/terminal/uartSerialPort.ts
+++ b/src/features/terminal/uartSerialPort.ts
@@ -68,14 +68,7 @@ export const connectToSerialPort = async (
                 port,
                 xTerminalShellParserWrapper(
                     new Terminal({ allowProposedApi: true, cols: 999 })
-                ),
-                {
-                    shellPromptUart: 'mosh:~$',
-                    logRegex:
-                        /[[][0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3},[0-9]{3}] <([^<^>]+)> ([^:]+): /,
-                    errorRegex: /ERROR/i,
-                    timeout: 10_000,
-                }
+                )
             );
             dispatch(setShellParser(shellParser));
         } else {

--- a/src/features/tracingEvents/at/sendCommand.ts
+++ b/src/features/tracingEvents/at/sendCommand.ts
@@ -51,12 +51,13 @@ const sendCommandShellMode = async (shellParser: ShellParser) => {
     do {
         const command = queue.shift();
         // eslint-disable-next-line no-await-in-loop
-        await shellParser.enqueueRequest(
-            `at ${command}`,
-            () => {},
-            () => {},
-            () => {}
-        );
+        await shellParser.enqueueRequest(`at ${command}`, {
+            onSuccess: () => {},
+            onError: err => {
+                console.error('There was an error', err);
+            },
+            onTimeout: () => {},
+        });
     } while (queue.length);
 };
 
@@ -134,24 +135,23 @@ export const detectDatabaseVersion = async (
             shellParser.unPause();
         }
         return new Promise<string | null>(resolve => {
-            shellParser.enqueueRequest(
-                `at ${atGetModemVersion}`,
-                (response: string) => {
+            shellParser.enqueueRequest(`at ${atGetModemVersion}`, {
+                onSuccess: (response: string) => {
                     resolve(getModemVersionFromResponse(response));
                 },
-                error => {
+                onError: error => {
                     logger.warn(
                         `Error while requesting modem firmware version: "${error}"`
                     );
                     resolve(null);
                 },
-                timeout => {
+                onTimeout: timeout => {
                     logger.warn(
                         `Timed out while requesting modem firmware version: "${timeout}"`
                     );
                     resolve(null);
-                }
-            );
+                },
+            });
         });
     }
 
@@ -184,22 +184,21 @@ export const sendSingleCommand = async (
             shellParser.unPause();
         }
         return new Promise<string | null>(resolve => {
-            shellParser.enqueueRequest(
-                `at ${command}`,
-                (response: string) => {
+            shellParser.enqueueRequest(`at ${command}`, {
+                onSuccess: (response: string) => {
                     resolve(getModemVersionFromResponse(response));
                 },
-                error => {
+                onError: error => {
                     logger.warn(`"${error}"`);
                     resolve(null);
                 },
-                timeout => {
+                onTimeout: timeout => {
                     logger.warn(
                         `Timed out while executing command: "${timeout}"`
                     );
                     resolve(null);
-                }
-            );
+                },
+            });
         });
     }
 


### PR DESCRIPTION
Because different device firmware can have different Zephyr Shell Prompts, we want to be able to automatically detect the prompt when we setup the shell parser.