### PR TITLE
Unregister parser in order to avoid issues

### DIFF
--- a/src/features/tracing/traceSlice.ts
+++ b/src/features/tracing/traceSlice.ts
@@ -139,10 +139,16 @@ const traceSlice = createSlice({
             state.uartSerialPort = action.payload;
         },
         setShellParser: (state, action: PayloadAction<ShellParser>) => {
+            if (state.shellParser != null) {
+                state.shellParser.unregister();
+            }
             state.shellParser = action.payload;
         },
         removeShellParser: state => {
-            state.shellParser = null;
+            if (state.shellParser != null) {
+                state.shellParser.unregister();
+                state.shellParser = null;
+            }
         },
         setTraceFormats: (state, action: PayloadAction<TraceFormat[]>) => {
             state.selectedFormats = action.payload;


### PR DESCRIPTION
Not releasing (unregister) the parser may cause issues related to performance, memory, and noise for active parsers. Hence, this commit enforces that the shell parser is always released when changed.