### PR TITLE
Update how to use

### DIFF
--- a/src/components/DocumentationSection.tsx
+++ b/src/components/DocumentationSection.tsx
@@ -10,18 +10,20 @@ import { DocumentationSection } from 'pc-nrfconnect-shared';
 import StartupDialog from '../features/startup/startupDialog';
 
 const DocumentationSections = [
-    <DocumentationSection
-        key="infocenter"
-        linkLabel="Go to Infocenter"
-        link="https://infocenter.nordicsemi.com/topic/ug_trace_collector/UG/trace_collector/intro.html"
-    >
-        Visit our Infocenter for more documentation about using the app.
-    </DocumentationSection>,
+    // <DocumentationSection
+    //     key="infocenter"
+    //     linkLabel="Go to Infocenter"
+    //     link="https://infocenter.nordicsemi.com/topic/ug_trace_collector/UG/trace_collector/intro.html"
+    // >
+    //     Visit our Infocenter for more documentation about using the app.
+    // </DocumentationSection>,
     <DocumentationSection
         key="credentialManager"
         linkLabel="Credential Manager"
         link="https://infocenter.nordicsemi.com/topic/ug_link_monitor/UG/link_monitor/lm_certificate_manager.html"
-    />,
+    >
+        Visit our Infocenter for more documentation about using the app.
+    </DocumentationSection>,
     <StartupDialog key="default-startup-dialog" />,
 ];
 

--- a/src/features/startup/startupDialog.tsx
+++ b/src/features/startup/startupDialog.tsx
@@ -98,8 +98,8 @@ const StartupDialog = () => {
                 </b>
                 <p>
                     If you use nRF Connect SDK v2.0.1 or higher, add the
-                    following Kconfig snippets to enable trace and AT commands*
-                    in your application firmware.
+                    following Kconfig snippets to enable trace, and optionally,
+                    AT commands in your application firmware.
                 </p>
                 <pre
                     style={{
@@ -133,8 +133,6 @@ const StartupDialog = () => {
                         <li>Modem firmware version 1.3.1 or higher</li>
                     </ul>
                 </p>
-
-                <p>* Optional</p>
             </div>
         </GenericDialog>
     );


### PR DESCRIPTION
Inline the comment about adding AT client, as that is the only optional step we refer to. Earlier we had multiple optional steps.

Additionally:
Comment out the generic Documentation to Infocenter for now. Will be added back once the Cellular Monitor specific documentation is released. For now just point to the Credential Manager documentation, from Link Monitor.