### PR TITLE
Notify about packets before stopping trace

### DIFF
--- a/src/features/tracing/nrfml.ts
+++ b/src/features/tracing/nrfml.ts
@@ -271,6 +271,7 @@ export const readRawTrace =
                     logger.info(`Completed reading trace from ${sourceFile}`);
                 }
                 setLoading(false);
+                notifyListeners(packets.splice(0, packets.length));
                 setTimeout(() => tracePacketEvents.emit('stop-process'), 1000);
             },
             () => {},


### PR DESCRIPTION
If monitor-lib finish parsing the trace before we have notified about new packets, the packets that are intermediately stored are lost. This commit enforces a notification of stored packets before trace is stopped.