### PR TITLE
Enable auto detect trace db on Load trace file

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## 1.0.3 - Unreleased
+
+### Added
+
+-   Option to auto detect trace database when reading trace file.
+
 ## 1.0.2 - 2023-06-15
 
 ### Fixed

--- a/src/components/SidePanel/DatabaseFileOverride.tsx
+++ b/src/components/SidePanel/DatabaseFileOverride.tsx
@@ -31,10 +31,6 @@ import EventAction from '../../usageDataActions';
 import { askForTraceDbFile } from '../../utils/fileUtils';
 import { deleteDbFilePath, storeManualDbFilePath } from '../../utils/store';
 
-interface Props {
-    disableAutoSelect?: boolean;
-}
-
 const autoSelectItem: DropdownItem = {
     label: 'Autoselect',
     value: 'autoselect',
@@ -45,18 +41,15 @@ const selectFromDiskItem = {
     value: 'select-trace-db',
 };
 
-export default ({ disableAutoSelect }: Props) => {
+export default () => {
     const dispatch = useDispatch();
     const manualDbFilePath = useSelector(getManualDbFilePath);
     const [databases, setDatabases] = useState<DatabaseVersion[]>([]);
-    const [selectedItem, setSelectedItem] = useState(
-        disableAutoSelect ? selectFromDiskItem : autoSelectItem
-    );
+    const [selectedItem, setSelectedItem] = useState(autoSelectItem);
     const isTracing = useSelector(getIsTracing);
 
-    const autoSelect = disableAutoSelect ? [] : [autoSelectItem];
     const items = [
-        ...autoSelect,
+        autoSelectItem,
         selectFromDiskItem,
         ...databases.map(database => ({
             label: database.version,

--- a/src/features/tracing/nrfml.ts
+++ b/src/features/tracing/nrfml.ts
@@ -242,6 +242,7 @@ export const readRawTrace =
     (dispatch, getState) => {
         const state = getState();
         const source: SourceFormat = { type: 'file', path: sourceFile };
+        const autoDetectTraceDb = getManualDbFilePath(getState()) == null;
 
         const packets: Packet[] = [];
         const throttle = setInterval(() => {
@@ -274,7 +275,12 @@ export const readRawTrace =
                 notifyListeners(packets.splice(0, packets.length));
                 setTimeout(() => tracePacketEvents.emit('stop-process'), 1000);
             },
-            () => {},
+            autoDetectTraceDb
+                ? makeProgressCallback(dispatch, {
+                      detectingTraceDb: true,
+                      displayDetectingTraceDbMessage: false,
+                  })
+                : () => {},
             data => {
                 const { dataReceived } = getState().app.trace;
                 if (!dataReceived) dispatch(setTraceDataReceived(true));


### PR DESCRIPTION
This commit enables the auto detection feature from monitor-lib on readRawTrace, which means that users can select the 'Auto Detect' option for trace database.

When a file is selected, you are prompted with the trace database options, and the default value is **Autoselect**, which will use the monitor-lib auto detection feature.

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor/assets/34618612/4049e356-75de-4f09-9f25-243882bd1743)
