### PR TITLE
Fix/limited serial ports

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,10 +3,19 @@
 ### Added
 
 -   Option to auto detect trace database when reading trace file.
+-   Option to deselect **Terminal Serial Port**.
 
 ### Fixed
 
 -   Programming sample could fail the first time programming an application.
+
+### Changed
+
+-   Renamed **Serial port trace capture** to **Modem trace serial port**.
+-   When selected device only expose one serial port, the app will assume it
+    will be used for modem trace. Hence, it will only auto-select serial port
+    for the **Modem trace serial port**, and will not select anything for
+    **Terminal serial port**.
 
 ## 1.0.2 - 2023-06-15
 

--- a/src/appReducer.ts
+++ b/src/appReducer.ts
@@ -10,6 +10,7 @@ import { combineReducers } from 'redux';
 import chartSlice from './features/dashboard/Chart/chartSlice';
 import modemReducer from './features/modem/modemSlice';
 import startupReducer from './features/startup/startupSlice';
+import serialPortReducer from './features/terminal/serialPortSlice';
 import traceReducer from './features/tracing/traceSlice';
 import dashboardReducer from './features/tracingEvents/dashboardSlice';
 import wiresharkReducer from './features/wireshark/wiresharkSlice';
@@ -25,6 +26,7 @@ const appReducer = combineReducers({
     dashboard: dashboardReducer,
     chart: chartSlice,
     startup: startupReducer,
+    serialPort: serialPortReducer,
 });
 
 export default appReducer;

--- a/src/components/DeviceSelector.ts
+++ b/src/components/DeviceSelector.ts
@@ -18,7 +18,7 @@ import {
 
 import {
     removeShellParser,
-    setSerialPort as setUartSerialPort,
+    setTerminalSerialPort as setUartSerialPort,
 } from '../features/terminal/serialPortSlice';
 import { autoSetUartSerialPort } from '../features/terminal/uartSerialPort';
 import { stopTrace } from '../features/tracing/nrfml';
@@ -28,7 +28,7 @@ import {
     resetTraceInfo,
     setAvailableSerialPorts,
     setDetectingTraceDb,
-    setSerialPort,
+    setTraceSerialPort,
 } from '../features/tracing/traceSlice';
 import { clearATQueue } from '../features/tracingEvents/at/sendCommand';
 import { resetDashboardState } from '../features/tracingEvents/dashboardSlice';
@@ -65,7 +65,7 @@ const closeDevice = (): TAction => dispatch => {
     logger.info('Closing device');
     dispatch(setUartSerialPort(null));
     dispatch(setAvailableSerialPorts([]));
-    dispatch(setSerialPort(null));
+    dispatch(setTraceSerialPort(null));
     dispatch(stopTrace());
     dispatch(setDetectingTraceDb(false));
     dispatch(removeShellParser());
@@ -80,7 +80,7 @@ const openDevice =
         resetTraceEvents();
         // Reset serial port settings
         dispatch(setAvailableSerialPorts([]));
-        dispatch(setSerialPort(null));
+        dispatch(setTraceSerialPort(null));
 
         dispatch(
             setAvailableSerialPorts(
@@ -97,13 +97,13 @@ const autoSetTraceSerialPort =
     dispatch => {
         const persistedPath = getPersistedSerialPort(device.serialNumber);
         if (persistedPath) {
-            dispatch(setSerialPort(persistedPath));
+            dispatch(setTraceSerialPort(persistedPath));
             return;
         }
         const port = autoSelectTraceSerialPort(device?.serialPorts ?? []);
         const path = port?.comName ?? device?.serialport?.comName;
         if (path) {
-            dispatch(setSerialPort(path));
+            dispatch(setTraceSerialPort(path));
         } else {
             logger.error("Couldn't identify trace serial port");
         }

--- a/src/components/DeviceSelector.ts
+++ b/src/components/DeviceSelector.ts
@@ -16,17 +16,19 @@ import {
     logger,
 } from 'pc-nrfconnect-shared';
 
+import {
+    removeShellParser,
+    setSerialPort as setUartSerialPort,
+} from '../features/terminal/serialPortSlice';
 import { autoSetUartSerialPort } from '../features/terminal/uartSerialPort';
 import { stopTrace } from '../features/tracing/nrfml';
 import { resetTraceEvents } from '../features/tracing/tracePacketEvents';
 import {
-    removeShellParser,
     resetManualDbFilePath,
     resetTraceInfo,
     setAvailableSerialPorts,
     setDetectingTraceDb,
     setSerialPort,
-    setUartSerialPort,
 } from '../features/tracing/traceSlice';
 import { clearATQueue } from '../features/tracingEvents/at/sendCommand';
 import { resetDashboardState } from '../features/tracingEvents/dashboardSlice';

--- a/src/components/SidePanel/DatabaseFileOverride.tsx
+++ b/src/components/SidePanel/DatabaseFileOverride.tsx
@@ -114,7 +114,7 @@ export default () => {
     return (
         <Dropdown
             disabled={isTracing}
-            label="Trace database"
+            label="Modem trace database"
             items={items}
             onSelect={onSelect}
             selectedItem={selectedItem}

--- a/src/components/SidePanel/LoadTraceFile.tsx
+++ b/src/components/SidePanel/LoadTraceFile.tsx
@@ -10,7 +10,7 @@ import { Button, ConfirmationDialog, usageData } from 'pc-nrfconnect-shared';
 
 import { readRawTrace } from '../../features/tracing/nrfml';
 import {
-    getSerialPort,
+    getTraceSerialPort,
     setManualDbFilePath,
 } from '../../features/tracing/traceSlice';
 import EventAction from '../../usageDataActions';
@@ -21,7 +21,7 @@ export const LoadTraceFile = () => {
     const dispatch = useDispatch();
     const [loading, setLoading] = useState(false);
     const [filePath, setFilePath] = useState<string>();
-    const hasSerialPort = useSelector(getSerialPort) != null;
+    const hasSerialPort = useSelector(getTraceSerialPort) != null;
     const [showTraceDbSelector, setShowTraceDbSelector] = useState(false);
 
     const readRawFile = async () => {

--- a/src/components/SidePanel/Macros.tsx
+++ b/src/components/SidePanel/Macros.tsx
@@ -8,11 +8,11 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Button, usageData } from 'pc-nrfconnect-shared';
 
+import { getSerialPort } from '../../features/terminal/serialPortSlice';
 import {
     getDetectedAtHostLibrary,
     getIsSendingATCommands,
     getIsTracing,
-    getUartSerialPort,
 } from '../../features/tracing/traceSlice';
 import {
     fullReport,
@@ -36,7 +36,7 @@ type Macro = {
 
 export const Macro = ({ commands, title }: Macro) => {
     const dispatch = useDispatch();
-    const serialPort = useSelector(getUartSerialPort);
+    const serialPort = useSelector(getSerialPort);
     const detectedAtHostLibrary = useSelector(getDetectedAtHostLibrary);
     const isTracing = useSelector(getIsTracing);
     const isSending = useSelector(getIsSendingATCommands);

--- a/src/components/SidePanel/Macros.tsx
+++ b/src/components/SidePanel/Macros.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Button, usageData } from 'pc-nrfconnect-shared';
 
-import { getSerialPort } from '../../features/terminal/serialPortSlice';
+import { getTerminalSerialPort } from '../../features/terminal/serialPortSlice';
 import {
     getDetectedAtHostLibrary,
     getIsSendingATCommands,
@@ -36,7 +36,7 @@ type Macro = {
 
 export const Macro = ({ commands, title }: Macro) => {
     const dispatch = useDispatch();
-    const serialPort = useSelector(getSerialPort);
+    const serialPort = useSelector(getTerminalSerialPort);
     const detectedAtHostLibrary = useSelector(getDetectedAtHostLibrary);
     const isTracing = useSelector(getIsTracing);
     const isSending = useSelector(getIsSendingATCommands);

--- a/src/components/SidePanel/Serialports.tsx
+++ b/src/components/SidePanel/Serialports.tsx
@@ -12,8 +12,8 @@ import {
     getAvailableSerialPorts,
     getIsTracing,
     getSelectedSerialNumber,
-    getSerialPort,
-    setSerialPort,
+    getTraceSerialPort,
+    setTraceSerialPort,
 } from '../../features/tracing/traceSlice';
 import { setSerialPort as persistSerialPort } from '../../utils/store';
 
@@ -21,11 +21,11 @@ export default () => {
     const dispatch = useDispatch();
     const availablePorts = useSelector(getAvailableSerialPorts);
     const serialNumber = useSelector(getSelectedSerialNumber) ?? '';
-    const selectedSerialPort = useSelector(getSerialPort);
+    const selectedSerialPort = useSelector(getTraceSerialPort);
     const isTracing = useSelector(getIsTracing);
 
     const updateSerialPort = ({ value: port }: { value: string }) => {
-        dispatch(setSerialPort(port));
+        dispatch(setTraceSerialPort(port));
         persistSerialPort(serialNumber, port);
     };
 

--- a/src/components/SidePanel/Serialports.tsx
+++ b/src/components/SidePanel/Serialports.tsx
@@ -43,7 +43,7 @@ export default () => {
     return (
         <div className="serialport-selection">
             <Dropdown
-                label="Serial port trace capture"
+                label="Modem trace serial port"
                 disabled={isTracing}
                 onSelect={updateSerialPort}
                 selectedItem={selectedItem}

--- a/src/components/SidePanel/Tracing/TraceCollector.tsx
+++ b/src/components/SidePanel/Tracing/TraceCollector.tsx
@@ -7,12 +7,12 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-import { getSerialPort } from '../../../features/tracing/traceSlice';
+import { getTraceSerialPort } from '../../../features/tracing/traceSlice';
 import DetectTraceDbDialog from './DetectTraceDbDialog';
 import StartStopTrace from './StartStopTrace';
 
 export default () => {
-    const selectedSerialPort = useSelector(getSerialPort);
+    const selectedSerialPort = useSelector(getTraceSerialPort);
 
     if (!selectedSerialPort) {
         return null;

--- a/src/components/SidePanel/__tests__/SidePanel.test.tsx
+++ b/src/components/SidePanel/__tests__/SidePanel.test.tsx
@@ -10,8 +10,8 @@ import { enableFetchMocks } from 'jest-fetch-mock';
 import { TraceFormat } from '../../../features/tracing/formats';
 import {
     setAvailableSerialPorts,
-    setSerialPort,
     setTraceFormats,
+    setTraceSerialPort,
 } from '../../../features/tracing/traceSlice';
 import {
     fireEvent,
@@ -68,7 +68,7 @@ jest.mock('electron', () => ({
 
 const serialPortActions = (formats: TraceFormat[] = []) => [
     setAvailableSerialPorts(['COM1', 'COM2', 'COM3']),
-    setSerialPort('COM1'),
+    setTraceSerialPort('COM1'),
     setTraceFormats(formats),
 ];
 

--- a/src/components/SidePanel/__tests__/TraceCollector.test.tsx
+++ b/src/components/SidePanel/__tests__/TraceCollector.test.tsx
@@ -8,8 +8,8 @@ import React from 'react';
 
 import {
     setAvailableSerialPorts,
-    setSerialPort,
     setTraceFormats,
+    setTraceSerialPort,
 } from '../../../features/tracing/traceSlice';
 import * as wireshark from '../../../features/wireshark/wireshark';
 import { setWiresharkPath } from '../../../features/wireshark/wiresharkSlice';
@@ -43,7 +43,7 @@ const serialPortActions = (
 ) => [
     setTraceFormats(formats),
     setAvailableSerialPorts(['COM1', 'COM2', 'COM3']),
-    setSerialPort('COM1'),
+    setTraceSerialPort('COM1'),
 ];
 
 describe('TraceCollector', () => {

--- a/src/features/certificateManager/CertificateManager.tsx
+++ b/src/features/certificateManager/CertificateManager.tsx
@@ -18,7 +18,10 @@ import { homedir } from 'os';
 import { logger, SerialPort } from 'pc-nrfconnect-shared';
 
 import { ShellParser } from '../shell/shellParser';
-import { getSerialPort, getShellParser } from '../terminal/serialPortSlice';
+import {
+    getShellParser,
+    getTerminalSerialPort,
+} from '../terminal/serialPortSlice';
 import { sendSingleCommand } from '../tracingEvents/at/sendCommand';
 
 const deleteTLSCredential = async (
@@ -122,7 +125,7 @@ export default ({ active }: { active: boolean }) => {
     const [secTag, setSecTag] = useState(NRF_CLOUD_TAG);
     const [showWarning, setShowWarning] = useState(false);
 
-    const uartPort = useSelector(getSerialPort);
+    const uartPort = useSelector(getTerminalSerialPort);
     const shellParser = useSelector(getShellParser);
 
     function parseSecTag(secTagAsString: string) {

--- a/src/features/certificateManager/CertificateManager.tsx
+++ b/src/features/certificateManager/CertificateManager.tsx
@@ -18,7 +18,7 @@ import { homedir } from 'os';
 import { logger, SerialPort } from 'pc-nrfconnect-shared';
 
 import { ShellParser } from '../shell/shellParser';
-import { getShellParser, getUartSerialPort } from '../tracing/traceSlice';
+import { getSerialPort, getShellParser } from '../terminal/serialPortSlice';
 import { sendSingleCommand } from '../tracingEvents/at/sendCommand';
 
 const deleteTLSCredential = async (
@@ -122,7 +122,7 @@ export default ({ active }: { active: boolean }) => {
     const [secTag, setSecTag] = useState(NRF_CLOUD_TAG);
     const [showWarning, setShowWarning] = useState(false);
 
-    const uartPort = useSelector(getUartSerialPort);
+    const uartPort = useSelector(getSerialPort);
     const shellParser = useSelector(getShellParser);
 
     function parseSecTag(secTagAsString: string) {

--- a/src/features/programSample/ProgramSampleModal.tsx
+++ b/src/features/programSample/ProgramSampleModal.tsx
@@ -22,13 +22,10 @@ import {
     setWaitForDevice,
 } from 'pc-nrfconnect-shared';
 
+import { setSerialPort } from '../terminal/serialPortSlice';
 import { autoSetUartSerialPort } from '../terminal/uartSerialPort';
 import { resetTraceEvents } from '../tracing/tracePacketEvents';
-import {
-    getIsTracing,
-    resetTraceInfo,
-    setUartSerialPort,
-} from '../tracing/traceSlice';
+import { getIsTracing, resetTraceInfo } from '../tracing/traceSlice';
 import { resetDashboardState } from '../tracingEvents/dashboardSlice';
 import {
     is91DK,
@@ -345,7 +342,7 @@ const ProgramSample = ({
 
                         try {
                             await downloadSample(sample);
-                            dispatch(setUartSerialPort(null));
+                            dispatch(setSerialPort(null));
 
                             await program(
                                 device,
@@ -561,7 +558,7 @@ const ProgramModem = ({
 
                             try {
                                 await downloadModemFirmware(selectedMfw);
-                                dispatch(setUartSerialPort(null));
+                                dispatch(setSerialPort(null));
 
                                 await programModemFirmware(
                                     device,

--- a/src/features/programSample/ProgramSampleModal.tsx
+++ b/src/features/programSample/ProgramSampleModal.tsx
@@ -22,7 +22,7 @@ import {
     setWaitForDevice,
 } from 'pc-nrfconnect-shared';
 
-import { setSerialPort } from '../terminal/serialPortSlice';
+import { setTerminalSerialPort } from '../terminal/serialPortSlice';
 import { autoSetUartSerialPort } from '../terminal/uartSerialPort';
 import { resetTraceEvents } from '../tracing/tracePacketEvents';
 import { getIsTracing, resetTraceInfo } from '../tracing/traceSlice';
@@ -342,7 +342,7 @@ const ProgramSample = ({
 
                         try {
                             await downloadSample(sample);
-                            dispatch(setSerialPort(null));
+                            dispatch(setTerminalSerialPort(null));
 
                             await program(
                                 device,
@@ -558,7 +558,7 @@ const ProgramModem = ({
 
                             try {
                                 await downloadModemFirmware(selectedMfw);
-                                dispatch(setSerialPort(null));
+                                dispatch(setTerminalSerialPort(null));
 
                                 await programModemFirmware(
                                     device,

--- a/src/features/terminal/SourceSelector.tsx
+++ b/src/features/terminal/SourceSelector.tsx
@@ -82,7 +82,7 @@ export default () => {
     return (
         <>
             <Dropdown
-                label="Terminal Serial Port"
+                label="Terminal serial port"
                 onSelect={item => {
                     if (item !== selectedSerialPortItem) {
                         setSelectedSerialPortItem(item);

--- a/src/features/terminal/SourceSelector.tsx
+++ b/src/features/terminal/SourceSelector.tsx
@@ -23,9 +23,9 @@ import {
     setShowConflictingSettingsDialog,
 } from '../tracing/traceSlice';
 import {
-    closeSerialPort,
-    getSerialPort,
-    setSerialPort,
+    closeTerminalSerialPort,
+    getTerminalSerialPort,
+    setTerminalSerialPort,
 } from './serialPortSlice';
 import { connectToSerialPort } from './uartSerialPort';
 
@@ -36,7 +36,7 @@ export default () => {
     const [serialPortItems, setSerialPortItems] = useState<DropdownItem[]>([]);
     const device = useSelector(selectedDevice);
     const availablePorts = useSelector(getAvailableSerialPorts);
-    const selectedUartSerialPort = useSelector(getSerialPort);
+    const selectedUartSerialPort = useSelector(getTerminalSerialPort);
     const showConflictingSettingsDialog = useSelector(
         getShowConflictingSettingsDialog
     );
@@ -70,7 +70,7 @@ export default () => {
 
     const connectToSerialPortWrapper = (path: string, overwrite = false) => {
         if (path === '') {
-            dispatch(closeSerialPort());
+            dispatch(closeTerminalSerialPort());
             return;
         }
         connectToSerialPort(dispatch, path, overwrite);
@@ -110,7 +110,7 @@ export default () => {
                     setSerialPortCallback={async (
                         newSerialPort: SerialPort
                     ) => {
-                        dispatch(setSerialPort(newSerialPort));
+                        dispatch(setTerminalSerialPort(newSerialPort));
                         const options = await newSerialPort.getOptions();
                         setSelectedSerialPortOptions(options);
                     }}

--- a/src/features/terminal/index.tsx
+++ b/src/features/terminal/index.tsx
@@ -16,11 +16,11 @@ import {
 } from 'pc-nrfconnect-shared';
 
 import EventAction from '../../usageDataActions';
-import { getSerialPort } from './serialPortSlice';
+import { getTerminalSerialPort } from './serialPortSlice';
 
 export const OpenSerialTerminal = () => {
     const device = useSelector(selectedDevice);
-    const selectedUartSerialPort = useSelector(getSerialPort);
+    const selectedUartSerialPort = useSelector(getTerminalSerialPort);
     const [appInstalled, setAppInstalled] = useState(false);
 
     useEffect(() => {

--- a/src/features/terminal/index.tsx
+++ b/src/features/terminal/index.tsx
@@ -16,11 +16,11 @@ import {
 } from 'pc-nrfconnect-shared';
 
 import EventAction from '../../usageDataActions';
-import { getUartSerialPort } from '../tracing/traceSlice';
+import { getSerialPort } from './serialPortSlice';
 
 export const OpenSerialTerminal = () => {
     const device = useSelector(selectedDevice);
-    const selectedUartSerialPort = useSelector(getUartSerialPort);
+    const selectedUartSerialPort = useSelector(getSerialPort);
     const [appInstalled, setAppInstalled] = useState(false);
 
     useEffect(() => {

--- a/src/features/terminal/serialPortSlice.ts
+++ b/src/features/terminal/serialPortSlice.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { SerialPort } from 'pc-nrfconnect-shared';
+
+import type { RootState } from '../../appReducer';
+import type { ShellParser } from '../shell/shellParser';
+
+interface SerialPortState {
+    readonly serialPort: SerialPort | null;
+    readonly shellParser: ShellParser | null;
+}
+
+const initialState: SerialPortState = {
+    serialPort: null,
+    shellParser: null,
+};
+
+const serialPortSlice = createSlice({
+    name: 'serialPort',
+    initialState,
+    reducers: {
+        setSerialPort: (
+            state,
+            { payload: newSerialPort }: PayloadAction<SerialPort | null>
+        ) => {
+            if (state.serialPort?.path === newSerialPort?.path) return;
+            if (state.serialPort != null) {
+                state.serialPort.close();
+            }
+            if (newSerialPort != null) {
+                state.serialPort = newSerialPort;
+            }
+        },
+        closeSerialPort: state => {
+            state.shellParser?.unregister();
+            state.shellParser = null;
+
+            state.serialPort?.close();
+            state.serialPort = null;
+        },
+        setShellParser: (state, action: PayloadAction<ShellParser>) => {
+            if (state.shellParser != null) {
+                state.shellParser.unregister();
+            }
+            state.shellParser = action.payload;
+        },
+        removeShellParser: state => {
+            if (state.shellParser != null) {
+                state.shellParser.unregister();
+                state.shellParser = null;
+            }
+        },
+    },
+});
+
+export const getSerialPort = (state: RootState) =>
+    state.app.serialPort.serialPort;
+
+export const getShellParser = (state: RootState) =>
+    state.app.serialPort.shellParser;
+
+export const {
+    setSerialPort,
+    closeSerialPort,
+    setShellParser,
+    removeShellParser,
+} = serialPortSlice.actions;
+
+export default serialPortSlice.reducer;

--- a/src/features/terminal/serialPortSlice.ts
+++ b/src/features/terminal/serialPortSlice.ts
@@ -11,37 +11,37 @@ import type { RootState } from '../../appReducer';
 import type { ShellParser } from '../shell/shellParser';
 
 interface SerialPortState {
-    readonly serialPort: SerialPort | null;
+    readonly terminalSerialPort: SerialPort | null;
     readonly shellParser: ShellParser | null;
 }
 
 const initialState: SerialPortState = {
-    serialPort: null,
+    terminalSerialPort: null,
     shellParser: null,
 };
 
 const serialPortSlice = createSlice({
-    name: 'serialPort',
+    name: 'terminalSerialPort',
     initialState,
     reducers: {
-        setSerialPort: (
+        setTerminalSerialPort: (
             state,
             { payload: newSerialPort }: PayloadAction<SerialPort | null>
         ) => {
-            if (state.serialPort?.path === newSerialPort?.path) return;
-            if (state.serialPort != null) {
-                state.serialPort.close();
+            if (state.terminalSerialPort?.path === newSerialPort?.path) return;
+            if (state.terminalSerialPort != null) {
+                state.terminalSerialPort.close();
             }
             if (newSerialPort != null) {
-                state.serialPort = newSerialPort;
+                state.terminalSerialPort = newSerialPort;
             }
         },
-        closeSerialPort: state => {
+        closeTerminalSerialPort: state => {
             state.shellParser?.unregister();
             state.shellParser = null;
 
-            state.serialPort?.close();
-            state.serialPort = null;
+            state.terminalSerialPort?.close();
+            state.terminalSerialPort = null;
         },
         setShellParser: (state, action: PayloadAction<ShellParser>) => {
             if (state.shellParser != null) {
@@ -58,15 +58,15 @@ const serialPortSlice = createSlice({
     },
 });
 
-export const getSerialPort = (state: RootState) =>
-    state.app.serialPort.serialPort;
+export const getTerminalSerialPort = (state: RootState) =>
+    state.app.serialPort.terminalSerialPort;
 
 export const getShellParser = (state: RootState) =>
     state.app.serialPort.shellParser;
 
 export const {
-    setSerialPort,
-    closeSerialPort,
+    setTerminalSerialPort,
+    closeTerminalSerialPort,
     setShellParser,
     removeShellParser,
 } = serialPortSlice.actions;

--- a/src/features/terminal/uartSerialPort.ts
+++ b/src/features/terminal/uartSerialPort.ts
@@ -21,8 +21,8 @@ import {
 import { testIfShellMode } from '../tracingEvents/at/sendCommand';
 import {
     removeShellParser,
-    setSerialPort,
     setShellParser,
+    setTerminalSerialPort,
 } from './serialPortSlice';
 
 const LOGGER_PREFIX = 'Terminal Serial Port:';
@@ -54,7 +54,7 @@ export const connectToSerialPort = async (
 
     if (!createdSerialPort) return;
 
-    dispatch(setSerialPort(createdSerialPort));
+    dispatch(setTerminalSerialPort(createdSerialPort));
 
     /*
          Some applications that run Line Mode have an issue, where if you power-cycle the device,

--- a/src/features/terminal/uartSerialPort.ts
+++ b/src/features/terminal/uartSerialPort.ts
@@ -15,22 +15,26 @@ import {
     xTerminalShellParserWrapper,
 } from '../shell/shellParser';
 import {
-    removeShellParser,
     setDetectedAtHostLibrary,
-    setShellParser,
     setShowConflictingSettingsDialog,
-    setUartSerialPort,
 } from '../tracing/traceSlice';
 import { testIfShellMode } from '../tracingEvents/at/sendCommand';
+import {
+    removeShellParser,
+    setSerialPort,
+    setShellParser,
+} from './serialPortSlice';
+
+const LOGGER_PREFIX = 'Terminal Serial Port:';
 
 export const connectToSerialPort = async (
     dispatch: Dispatch,
     path: string,
     overwrite = false
 ) => {
-    let port;
+    let createdSerialPort;
     try {
-        port = await createSerialPort(
+        createdSerialPort = await createSerialPort(
             {
                 path,
                 baudRate: 115200,
@@ -43,12 +47,14 @@ export const connectToSerialPort = async (
             dispatch(setShowConflictingSettingsDialog(true));
         } else {
             logger.error(
-                'Port could not be opened. Verify it is not used by some other applications'
+                `${LOGGER_PREFIX} Port could not be opened. Verify it is not used by some other applications`
             );
         }
     }
 
-    if (!port) return;
+    if (!createdSerialPort) return;
+
+    dispatch(setSerialPort(createdSerialPort));
 
     /*
          Some applications that run Line Mode have an issue, where if you power-cycle the device,
@@ -57,42 +63,58 @@ export const connectToSerialPort = async (
          ERROR if it's in line mode. Since we already got the ERROR, we won't unexpectedly get it again
          the next time we send a command.
          */
-    const isShellMode = await raceTimeout(testIfShellMode(port));
+    const isShellMode = await raceTimeout(testIfShellMode(createdSerialPort));
+    // If race times out, then we assume AT Host is not detected on device.
+    const detectedAtHostLibrary = isShellMode !== undefined;
 
-    if (isShellMode === undefined) {
-        dispatch(setDetectedAtHostLibrary(false));
-    } else {
+    if (detectedAtHostLibrary) {
         dispatch(setDetectedAtHostLibrary(true));
+
         if (isShellMode) {
-            const shellParser = await hookModemToShellParser(
-                port,
-                xTerminalShellParserWrapper(
-                    new Terminal({ allowProposedApi: true, cols: 999 })
+            logger.debug(
+                `${LOGGER_PREFIX} Detected AT Host Library: Device is in shell mode`
+            );
+            dispatch(
+                setShellParser(
+                    await hookModemToShellParser(
+                        createdSerialPort,
+                        xTerminalShellParserWrapper(
+                            new Terminal({ allowProposedApi: true, cols: 999 })
+                        )
+                    )
                 )
             );
-            dispatch(setShellParser(shellParser));
         } else {
+            logger.debug(
+                `${LOGGER_PREFIX} Detected AT Host Library: Device is in Line mode`
+            );
             dispatch(removeShellParser());
         }
+    } else {
+        logger.debug(`${LOGGER_PREFIX} Could not detect AT Host library`);
+        dispatch(setDetectedAtHostLibrary(false));
+        dispatch(removeShellParser());
     }
-
-    return port;
 };
 
 export const autoSetUartSerialPort =
     (device: Device): TAction =>
-    async dispatch => {
-        const port = device.serialPorts?.at(0);
-        if (port && port.comName) {
-            const uartSerialPort = await connectToSerialPort(
-                dispatch,
-                port.comName
+    dispatch => {
+        if (!device.serialPorts || device.serialPorts.length < 2) {
+            logger.debug(
+                `${LOGGER_PREFIX} Fewer than two serial ports exposed, and will therefore not auto-connect.`
             );
-
-            if (uartSerialPort) {
-                dispatch(setUartSerialPort(uartSerialPort));
-            }
+            return;
+        }
+        const serialPortPath = device.serialPorts?.at(0)?.comName;
+        if (serialPortPath) {
+            connectToSerialPort(dispatch, serialPortPath);
+            logger.debug(
+                `${LOGGER_PREFIX} Will attempt to auto-connect to serial port ${serialPortPath}`
+            );
         } else {
-            logger.error('Could not identify serial port');
+            logger.error(
+                `${LOGGER_PREFIX} Serial port found, but could not identify serial port path`
+            );
         }
     };

--- a/src/features/tracing/nrfml.test.ts
+++ b/src/features/tracing/nrfml.test.ts
@@ -40,10 +40,14 @@ const mockStore = getMockStore();
 const initialState = {
     app: {
         trace: {
+            traceSerialPort: 'COM3',
             traceData: [],
-            serialPort: 'COM1',
         },
         wireshark: {},
+        serialPort: {
+            terminalSerialPort: null,
+            shellParser: null,
+        },
     },
     device: {
         devices: {},

--- a/src/features/tracing/nrfml.ts
+++ b/src/features/tracing/nrfml.ts
@@ -19,6 +19,10 @@ import EventAction from '../../usageDataActions';
 import { raceTimeout } from '../../utils/promise';
 import type { TAction } from '../../utils/thunk';
 import { is91DK } from '../programSample/programSample';
+import {
+    getSerialPort as getUartSerialPort,
+    getShellParser,
+} from '../terminal/serialPortSlice';
 import { detectDatabaseVersion } from '../tracingEvents/at/sendCommand';
 import { resetDashboardState } from '../tracingEvents/dashboardSlice';
 import { hasProgress, sinkEvent, SourceFormat, TraceFormat } from './formats';
@@ -36,9 +40,7 @@ import {
     getManualDbFilePath,
     getResetDevice,
     getSerialPort,
-    getShellParser,
     getTaskId,
-    getUartSerialPort,
     setDetectTraceDbFailed,
     setManualDbFilePath,
     setTraceDataReceived,

--- a/src/features/tracing/nrfml.ts
+++ b/src/features/tracing/nrfml.ts
@@ -20,8 +20,8 @@ import { raceTimeout } from '../../utils/promise';
 import type { TAction } from '../../utils/thunk';
 import { is91DK } from '../programSample/programSample';
 import {
-    getSerialPort as getUartSerialPort,
     getShellParser,
+    getTerminalSerialPort as getUartSerialPort,
 } from '../terminal/serialPortSlice';
 import { detectDatabaseVersion } from '../tracingEvents/at/sendCommand';
 import { resetDashboardState } from '../tracingEvents/dashboardSlice';
@@ -39,8 +39,8 @@ import {
 import {
     getManualDbFilePath,
     getResetDevice,
-    getSerialPort,
     getTaskId,
+    getTraceSerialPort,
     setDetectTraceDbFailed,
     setManualDbFilePath,
     setTraceDataReceived,
@@ -127,7 +127,7 @@ export const startTrace =
         const state = getState();
         const uartPort = getUartSerialPort(state);
         const shellParser = getShellParser(state);
-        const tracePort = getSerialPort(state);
+        const tracePort = getTraceSerialPort(state);
         const resetDevice = getResetDevice(state);
 
         if (!tracePort) {

--- a/src/features/tracing/traceDatabase.ts
+++ b/src/features/tracing/traceDatabase.ts
@@ -8,12 +8,12 @@ import { existsSync, mkdirSync } from 'fs';
 import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { logger } from 'pc-nrfconnect-shared';
-import { TDispatch } from 'pc-nrfconnect-shared/src/state';
 
 import {
     autoDetectDbRootFolder,
     storeManualDbFilePath,
 } from '../../utils/store';
+import { TDispatch } from '../../utils/thunk';
 import { setManualDbFilePath } from './traceSlice';
 
 interface TraceConfig {

--- a/src/features/tracing/traceSlice.ts
+++ b/src/features/tracing/traceSlice.ts
@@ -27,7 +27,7 @@ interface TraceState {
     taskId: TaskId | null;
     dataReceived: boolean;
     sourceFilePath: string | null;
-    serialPort: string | null;
+    traceSerialPort: string | null;
     availableSerialPorts: string[];
     manualDbFilePath?: string;
     detectingTraceDb: boolean;
@@ -46,7 +46,7 @@ const initialState = (): TraceState => ({
     taskId: null,
     dataReceived: false,
     sourceFilePath: null,
-    serialPort: null,
+    traceSerialPort: null,
     availableSerialPorts: [],
     manualDbFilePath: getPersistedManualDbFilePath(),
     detectingTraceDb: false,
@@ -107,8 +107,8 @@ const traceSlice = createSlice({
         setAvailableSerialPorts: (state, action: PayloadAction<string[]>) => {
             state.availableSerialPorts = action.payload;
         },
-        setSerialPort: (state, action: PayloadAction<string | null>) => {
-            state.serialPort = action.payload;
+        setTraceSerialPort: (state, action: PayloadAction<string | null>) => {
+            state.traceSerialPort = action.payload;
         },
         setManualDbFilePath: (
             state,
@@ -153,9 +153,10 @@ export const getTaskId = (state: RootState) => state.app.trace.taskId;
 export const getIsTracing = (state: RootState) =>
     state.app.trace.taskId != null;
 
-export const getSerialPort = (state: RootState) => state.app.trace.serialPort;
+export const getTraceSerialPort = (state: RootState) =>
+    state.app.trace.traceSerialPort;
 export const getIsDeviceSelected = (state: RootState) =>
-    state.app.trace.serialPort != null;
+    state.app.trace.traceSerialPort != null;
 
 export const getAvailableSerialPorts = (state: RootState) =>
     state.app.trace.availableSerialPorts;
@@ -199,7 +200,7 @@ export const {
     setTraceProgress,
     setTraceDataReceived,
     setTraceSourceFilePath,
-    setSerialPort,
+    setTraceSerialPort,
     setAvailableSerialPorts,
     setManualDbFilePath,
     resetManualDbFilePath,

--- a/src/features/tracing/traceSlice.ts
+++ b/src/features/tracing/traceSlice.ts
@@ -5,7 +5,6 @@
  */
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { SerialPort } from 'pc-nrfconnect-shared';
 
 import type { RootState } from '../../appReducer';
 import {
@@ -15,7 +14,6 @@ import {
     setTraceFormats as storeTraceFormats,
     storeResetDevice,
 } from '../../utils/store';
-import { ShellParser } from '../shell/shellParser';
 import { TraceFormat } from './formats';
 import type { TaskId } from './nrfml';
 
@@ -33,8 +31,6 @@ interface TraceState {
     availableSerialPorts: string[];
     manualDbFilePath?: string;
     detectingTraceDb: boolean;
-    readonly uartSerialPort: SerialPort | null;
-    readonly shellParser: ShellParser | null;
     selectedFormats: TraceFormat[];
     showConflictingSettingsDialog: boolean;
     // From Device config.prj --> AT_HOST=y
@@ -54,8 +50,6 @@ const initialState = (): TraceState => ({
     availableSerialPorts: [],
     manualDbFilePath: getPersistedManualDbFilePath(),
     detectingTraceDb: false,
-    uartSerialPort: null,
-    shellParser: null,
     selectedFormats: restoreTraceFormats(),
     showConflictingSettingsDialog: false,
     detectedAtHostLibrary: false,
@@ -128,28 +122,6 @@ const traceSlice = createSlice({
         setDetectingTraceDb: (state, action: PayloadAction<boolean>) => {
             state.detectingTraceDb = action.payload;
         },
-        setUartSerialPort: (
-            state,
-            action: PayloadAction<SerialPort | null>
-        ) => {
-            if (state.uartSerialPort?.path === action.payload?.path) return;
-            if (state.uartSerialPort != null) {
-                state.uartSerialPort.close();
-            }
-            state.uartSerialPort = action.payload;
-        },
-        setShellParser: (state, action: PayloadAction<ShellParser>) => {
-            if (state.shellParser != null) {
-                state.shellParser.unregister();
-            }
-            state.shellParser = action.payload;
-        },
-        removeShellParser: state => {
-            if (state.shellParser != null) {
-                state.shellParser.unregister();
-                state.shellParser = null;
-            }
-        },
         setTraceFormats: (state, action: PayloadAction<TraceFormat[]>) => {
             state.selectedFormats = action.payload;
             storeTraceFormats(action.payload);
@@ -200,11 +172,6 @@ export const getSelectedSerialNumber = (state: RootState) =>
 export const getDetectingTraceDb = (state: RootState) =>
     state.app.trace.detectingTraceDb;
 
-export const getUartSerialPort = (state: RootState) =>
-    state.app.trace.uartSerialPort;
-
-export const getShellParser = (state: RootState) => state.app.trace.shellParser;
-
 export const getTraceFormats = (state: RootState) =>
     state.app.trace.selectedFormats;
 
@@ -237,9 +204,6 @@ export const {
     setManualDbFilePath,
     resetManualDbFilePath,
     setDetectingTraceDb,
-    setUartSerialPort,
-    setShellParser,
-    removeShellParser,
     setTraceFormats,
     setShowConflictingSettingsDialog,
     setDetectedAtHostLibrary,

--- a/src/features/tracingEvents/at/sendCommand.ts
+++ b/src/features/tracingEvents/at/sendCommand.ts
@@ -8,7 +8,10 @@ import { logger, SerialPort } from 'pc-nrfconnect-shared';
 
 import { TAction } from '../../../utils/thunk';
 import { ShellParser } from '../../shell/shellParser';
-import { getSerialPort, getShellParser } from '../../terminal/serialPortSlice';
+import {
+    getShellParser,
+    getTerminalSerialPort,
+} from '../../terminal/serialPortSlice';
 import { setIsSendingATCommands } from '../../tracing/traceSlice';
 
 const decoder = new TextDecoder();
@@ -19,7 +22,7 @@ export const clearATQueue = () => queue.splice(0, queue.length);
 export const sendAT =
     (commands: string | string[]): TAction =>
     async (dispatch, getState) => {
-        const uartSerialPort = getSerialPort(getState());
+        const uartSerialPort = getTerminalSerialPort(getState());
         const shellParser = getShellParser(getState());
 
         const commandList = Array.isArray(commands) ? commands : [commands];

--- a/src/features/tracingEvents/at/sendCommand.ts
+++ b/src/features/tracingEvents/at/sendCommand.ts
@@ -8,11 +8,8 @@ import { logger, SerialPort } from 'pc-nrfconnect-shared';
 
 import { TAction } from '../../../utils/thunk';
 import { ShellParser } from '../../shell/shellParser';
-import {
-    getShellParser,
-    getUartSerialPort,
-    setIsSendingATCommands,
-} from '../../tracing/traceSlice';
+import { getSerialPort, getShellParser } from '../../terminal/serialPortSlice';
+import { setIsSendingATCommands } from '../../tracing/traceSlice';
 
 const decoder = new TextDecoder();
 const queue: string[] = [];
@@ -22,7 +19,7 @@ export const clearATQueue = () => queue.splice(0, queue.length);
 export const sendAT =
     (commands: string | string[]): TAction =>
     async (dispatch, getState) => {
-        const uartSerialPort = getUartSerialPort(getState());
+        const uartSerialPort = getSerialPort(getState());
         const shellParser = getShellParser(getState());
 
         const commandList = Array.isArray(commands) ? commands : [commands];


### PR DESCRIPTION
This PR addresses a few different aspects of using Serial Ports in Cellular Monitor.

One assumption, is that if a device is connected, and only exposes a single serial port, then we assume that the serial port will be used for tracing.

This PR enables users to deselect the **terminal serial port**

This PR separates the **terminal serial port** from the `tracing` section of the redux store, because conceptually the **terminal serial port** is not related to tracing. Hence, it is now included in its own section of the redux store, called `serialPort`.

This PR introduces more debug logging for the process of connecting to a **terminal  serial port**, which will hopefully help us when debugging this feature in the future.