### PR TITLE
Fix/cpsms clear

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@
     will be used for modem trace. Hence, it will only auto-select serial port
     for the **Modem trace serial port**, and will not select anything for
     **Terminal serial port**.
+-   Dashboard card title from Power Saving Mode to Power Saving Features.
 
 ## 1.0.2 - 2023-06-15
 

--- a/resources/docs/dashboardFields.ts
+++ b/resources/docs/dashboardFields.ts
@@ -347,7 +347,7 @@ register to.
             commands: ['AT+CPINR'] as const,
         },
     },
-    'Power Saving Mode': {
+    'Power Saving Features': {
         'REQUESTED ACTIVE TIMER': {
             title: 'Requested Active Timer (T3324)',
             description:

--- a/src/features/dashboard/Cards/PowerSavingMode.tsx
+++ b/src/features/dashboard/Cards/PowerSavingMode.tsx
@@ -96,7 +96,7 @@ export default () => {
     return (
         <DashboardCard
             key="dashboard-psm-card"
-            title="Power Saving Mode"
+            title="Power Saving Features"
             iconName="mdi-lightning-bolt-circle"
             fields={fields}
         />

--- a/src/features/tracingEvents/at/commandProcessors/modemParameters.test.ts
+++ b/src/features/tracingEvents/at/commandProcessors/modemParameters.test.ts
@@ -98,7 +98,6 @@ const modernModemVersionPacket = {
 
         powerSavingMode: {
             granted: {
-                state: 'on',
                 T3324: {
                     activated: true,
                     bitmask: '00000010',
@@ -142,7 +141,6 @@ const legacyModemVersionPacket = {
 
         powerSavingMode: {
             granted: {
-                state: 'on',
                 T3324: {
                     activated: true,
                     bitmask: '00000010',

--- a/src/features/tracingEvents/at/commandProcessors/modemParameters.ts
+++ b/src/features/tracingEvents/at/commandProcessors/modemParameters.ts
@@ -110,15 +110,6 @@ const parsePSMValues = (
         );
     }
 
-    if (
-        PsmValues.T3324.activated &&
-        (PsmValues?.T3412Extended?.activated || PsmValues?.T3412?.activated)
-    ) {
-        PsmValues.state = 'on';
-    } else {
-        PsmValues.state = 'off';
-    }
-
     return PsmValues;
 };
 

--- a/src/features/tracingEvents/at/commandProcessors/networkRegistrationStatusNotification.test.ts
+++ b/src/features/tracingEvents/at/commandProcessors/networkRegistrationStatusNotification.test.ts
@@ -15,7 +15,7 @@ READ CMD: AT+CEREG?
     - [<tac>]               ==> When n >= 2
     - [<ci>]                ==> When n >= 2
     - [<AcT>]               ==> When n >= 2
-    - [<cause_type>]        ==> When n = 3 or 5 FIXME: Unsure how its presented 
+    - [<cause_type>]        ==> When n = 3 or 5 FIXME: Unsure how its presented
     - [<reject_cause>]      ==> When n = 3 or 5 FIXME: Unsure how its presented (this it's one of  2 | 3 | 6 | 9 | 10, according to 3GPP 24.301 Annex A.1)
     - [<Active-Time>]       ==> When n >= 4
     - [<Periodic-TAU>]      ==> When n >= 4
@@ -91,7 +91,6 @@ const testResponses = [
             AcTState: 7,
             powerSavingMode: {
                 granted: {
-                    state: 'on',
                     T3412Extended: {
                         bitmask: '00100010',
                         value: 7200,

--- a/src/features/tracingEvents/at/commandProcessors/networkRegistrationStatusNotification.ts
+++ b/src/features/tracingEvents/at/commandProcessors/networkRegistrationStatusNotification.ts
@@ -163,9 +163,8 @@ const handleNetworkRegPayload = (
             networkRegState.ceregRejectCause = parseInt(rejectCause, 10);
         }
     }
-    let grantedPSM: PowerSavingModeEntries | undefined;
+    const grantedPSM: PowerSavingModeEntries = {};
     if (responseArray.length >= 9) {
-        grantedPSM = { state: 'on' };
         const T3324Bitmask = responseArray[index.T3324];
         if (isValidBitmask(T3324Bitmask)) {
             grantedPSM.T3324 = {

--- a/src/features/tracingEvents/at/commandProcessors/powerSavingModeSettings.test.ts
+++ b/src/features/tracingEvents/at/commandProcessors/powerSavingModeSettings.test.ts
@@ -7,14 +7,14 @@
 import { atPacket, convertPackets, OkPacket } from '../testUtils';
 
 /*
-==> AT+CPSMS= 
+==> AT+CPSMS=
 is a set command to turn off PSM, and also reset the timer values to manufacturer defaults.
 the defaults are:
 t3324      = 000 00110 = 0x21 = 1 minute
-t3412ext   = 001 00001 = 0x06 = 60 minutes 
+t3412ext   = 001 00001 = 0x06 = 60 minutes
 */
 
-const CPSMS = 'AT+CPSMS';
+const CPSMS = 'AT+cpsms';
 
 const defaultT3324 = '00100001';
 const notDefaultT3324 = '00100011';
@@ -22,9 +22,10 @@ const notDefaultT3324 = '00100011';
 const defaultT3412Extended = '00000110';
 const notDefaultT3412Extended = '10101010';
 
+const DISABLED = '11100000';
+
 test('AT+CPSMS=1 with only mode argument will use default values for t3324 and t3412ext', () => {
     let state = convertPackets([atPacket(`${CPSMS}=1`), OkPacket]);
-    expect(state.powerSavingMode?.requested?.state).toBe('on');
 
     expect(state.powerSavingMode?.requested?.T3324?.bitmask).toBe(defaultT3324);
     expect(state.powerSavingMode?.requested?.T3412Extended?.bitmask).toBe(
@@ -32,7 +33,6 @@ test('AT+CPSMS=1 with only mode argument will use default values for t3324 and t
     );
 
     state = convertPackets([atPacket(`${CPSMS}=0`), OkPacket]);
-    expect(state.powerSavingMode?.requested?.state).toBe('off');
 
     state = convertPackets([
         atPacket(
@@ -40,7 +40,6 @@ test('AT+CPSMS=1 with only mode argument will use default values for t3324 and t
         ),
         OkPacket,
     ]);
-    expect(state.powerSavingMode?.requested?.state).toBe('on');
     expect(state.powerSavingMode?.requested?.T3324?.bitmask).toBe(
         notDefaultT3324
     );
@@ -50,15 +49,13 @@ test('AT+CPSMS=1 with only mode argument will use default values for t3324 and t
 
     // Try to reset to default, to check if "AT+CPSMS=" command is interpreted correctly:
     state = convertPackets([atPacket(`${CPSMS}=`), OkPacket]);
-    expect(state.powerSavingMode?.requested?.state).toBe('off');
-    expect(state.powerSavingMode?.requested?.T3324?.bitmask).toBe(defaultT3324);
+    expect(state.powerSavingMode?.requested?.T3324?.bitmask).toBe(DISABLED);
     expect(state.powerSavingMode?.requested?.T3412Extended?.bitmask).toBe(
-        defaultT3412Extended
+        DISABLED
     );
 
     // Then check if the defaults are still used when using the short term on command
     state = convertPackets([atPacket(`${CPSMS}=1`), OkPacket]);
-    expect(state.powerSavingMode?.requested?.state).toBe('on');
     expect(state.powerSavingMode?.requested?.T3324?.bitmask).toBe(defaultT3324);
     expect(state.powerSavingMode?.requested?.T3412Extended?.bitmask).toBe(
         defaultT3412Extended
@@ -72,7 +69,6 @@ test('AT+CPSMS? read command will update the state appropriately', () => {
         atPacket(`${CPSMS}?`),
         atPacket(`+CPSMS: 1,,,"${t3412ext}","${t3324}"\r\nOK\r\n`),
     ]);
-    expect(state.powerSavingMode?.requested?.state).toBe('on');
     expect(state.powerSavingMode?.requested?.T3412Extended?.bitmask).toBe(
         t3412ext
     );
@@ -83,9 +79,54 @@ test('AT+CPSMS? read command will update the state appropriately', () => {
         atPacket(`${CPSMS}?`),
         atPacket(`+CPSMS: 1,,,"${t3412ext}","${t3324}"\r\nOK\r\n`),
     ]);
-    expect(state.powerSavingMode?.requested?.state).toBe('on');
     expect(state.powerSavingMode?.requested?.T3412Extended?.bitmask).toBe(
         t3412ext
     );
     expect(state.powerSavingMode?.requested?.T3324?.bitmask).toBe(t3324);
+});
+
+// test('AT+CPSMS= compared to AT+CPSMS=0', () => {
+test('This should be easy to find', () => {
+    const [t3412ext, t3324] = ['10101011', '00101010'];
+
+    let state = convertPackets([atPacket(`${CPSMS}=1`), OkPacket]);
+    expect(state.powerSavingMode?.requested?.T3324?.bitmask).toBe(defaultT3324);
+    expect(state.powerSavingMode?.requested?.T3412Extended?.bitmask).toBe(
+        defaultT3412Extended
+    );
+
+    state = convertPackets(
+        [atPacket(`${CPSMS}=1,,,"${t3412ext}","${t3324}"`), OkPacket],
+        state
+    );
+    expect(state.powerSavingMode?.requested?.T3412Extended?.bitmask).toBe(
+        t3412ext
+    );
+    expect(state.powerSavingMode?.requested?.T3324?.bitmask).toBe(t3324);
+
+    state = convertPackets([atPacket(`${CPSMS}=0`), OkPacket], state);
+    expect(state.powerSavingMode?.requested?.T3412Extended?.bitmask).toBe(
+        DISABLED
+    );
+    expect(state.powerSavingMode?.requested?.T3324?.bitmask).toBe(DISABLED);
+
+    // Verify that since AT+CPSMS=0 was sent, we persist the last requested parameters.
+    state = convertPackets([atPacket(`${CPSMS}=1`), OkPacket], state);
+    expect(state.powerSavingMode?.requested?.T3412Extended?.bitmask).toBe(
+        t3412ext
+    );
+    expect(state.powerSavingMode?.requested?.T3324?.bitmask).toBe(t3324);
+
+    state = convertPackets([atPacket(`${CPSMS}=`), OkPacket], state);
+    expect(state.powerSavingMode?.requested?.T3412Extended?.bitmask).toBe(
+        DISABLED
+    );
+    expect(state.powerSavingMode?.requested?.T3324?.bitmask).toBe(DISABLED);
+
+    // verify that since AT+CPSMS= was sent, then turning it back on requests default values.
+    state = convertPackets([atPacket(`${CPSMS}=1`), OkPacket], state);
+    expect(state.powerSavingMode?.requested?.T3324?.bitmask).toBe(defaultT3324);
+    expect(state.powerSavingMode?.requested?.T3412Extended?.bitmask).toBe(
+        defaultT3412Extended
+    );
 });

--- a/src/features/tracingEvents/at/commandProcessors/powerSavingModeSettings.ts
+++ b/src/features/tracingEvents/at/commandProcessors/powerSavingModeSettings.ts
@@ -58,13 +58,11 @@ export const processor: Processor<'+CPSMS'> = {
             } else {
                 // Then we must have gotten the `AT+CPSMS=` command
                 // Which means we should turn PSM off and reset timers to default.
-                console.log('Got the AT+CPSMS= command');
                 storedPowerSavingMode = resetToDefault;
                 setRequested = resetToDisabled;
             }
         }
         if (packet.requestType === RequestType.SET) {
-            console.log('This is just the RequestType.Set');
             setRequested = resetToDefault;
         }
         return state;
@@ -114,18 +112,9 @@ const parsePowerSavingModePayload = (
     if (mode === '0') {
         if (currentRequestedValues) {
             storedPowerSavingMode = currentRequestedValues;
-            console.log(
-                'Will persist current requested values: ',
-                currentRequestedValues
-            );
         }
         return { T3324: disabledT3324, T3412Extended: disabledT3412Extended };
     }
-
-    console.log(
-        'Turning on PSM, have stored values from before:',
-        storedPowerSavingMode
-    );
 
     return {
         T3324:

--- a/src/features/tracingEvents/at/commandProcessors/powerSavingModeSettings.ts
+++ b/src/features/tracingEvents/at/commandProcessors/powerSavingModeSettings.ts
@@ -22,14 +22,24 @@ const defaultT3412Extended = parsePowerSavingMode(
     '00000110',
     TAU_TYPES.SLEEP_INTERVAL
 );
+const disabledT3324 = parsePowerSavingMode('11100000', TAU_TYPES.ACTIVE_TIMER);
+const disabledT3412Extended = parsePowerSavingMode(
+    '11100000',
+    TAU_TYPES.SLEEP_INTERVAL
+);
 
 const resetToDefault = {
-    state: 'off',
     T3324: defaultT3324,
     T3412Extended: defaultT3412Extended,
 } as PowerSavingModeEntries;
 
+const resetToDisabled = {
+    T3324: disabledT3324,
+    T3412Extended: disabledT3412Extended,
+} as PowerSavingModeEntries;
+
 let setRequested: PowerSavingModeEntries;
+let storedPowerSavingMode: PowerSavingModeEntries;
 
 export const processor: Processor<'+CPSMS'> = {
     command: '+CPSMS',
@@ -41,14 +51,20 @@ export const processor: Processor<'+CPSMS'> = {
     onRequest: (packet, state) => {
         if (packet.requestType === RequestType.SET_WITH_VALUE) {
             if (packet.payload) {
-                setRequested = parsePowerSavingModePayload(packet.payload);
+                setRequested = parsePowerSavingModePayload(
+                    packet.payload,
+                    state?.powerSavingMode?.requested
+                );
             } else {
                 // Then we must have gotten the `AT+CPSMS=` command
                 // Which means we should turn PSM off and reset timers to default.
-                setRequested = resetToDefault;
+                console.log('Got the AT+CPSMS= command');
+                storedPowerSavingMode = resetToDefault;
+                setRequested = resetToDisabled;
             }
         }
         if (packet.requestType === RequestType.SET) {
+            console.log('This is just the RequestType.Set');
             setRequested = resetToDefault;
         }
         return state;
@@ -88,25 +104,40 @@ export const processor: Processor<'+CPSMS'> = {
     },
 };
 
-const parsePowerSavingModePayload = (payload: string) => {
+const parsePowerSavingModePayload = (
+    payload: string,
+    currentRequestedValues?: PowerSavingModeEntries
+) => {
     const [mode, , , T3412ExtendedBitmask, T3324Bitmask] =
         getParametersFromResponse(payload);
 
-    const result = {
-        state: mode === '1' ? 'on' : 'off',
-    } as PowerSavingModeEntries;
+    if (mode === '0') {
+        if (currentRequestedValues) {
+            storedPowerSavingMode = currentRequestedValues;
+            console.log(
+                'Will persist current requested values: ',
+                currentRequestedValues
+            );
+        }
+        return { T3324: disabledT3324, T3412Extended: disabledT3412Extended };
+    }
 
-    result.T3324 =
-        T3324Bitmask !== undefined
-            ? parsePowerSavingMode(T3324Bitmask, TAU_TYPES.ACTIVE_TIMER)
-            : defaultT3324;
-    result.T3412Extended =
-        T3412ExtendedBitmask !== undefined
-            ? parsePowerSavingMode(
-                  T3412ExtendedBitmask,
-                  TAU_TYPES.SLEEP_INTERVAL
-              )
-            : defaultT3412Extended;
+    console.log(
+        'Turning on PSM, have stored values from before:',
+        storedPowerSavingMode
+    );
 
-    return result;
+    return {
+        T3324:
+            T3324Bitmask !== undefined
+                ? parsePowerSavingMode(T3324Bitmask, TAU_TYPES.ACTIVE_TIMER)
+                : storedPowerSavingMode?.T3324 ?? defaultT3324,
+        T3412Extended:
+            T3412ExtendedBitmask !== undefined
+                ? parsePowerSavingMode(
+                      T3412ExtendedBitmask,
+                      TAU_TYPES.SLEEP_INTERVAL
+                  )
+                : storedPowerSavingMode?.T3412Extended ?? defaultT3412Extended,
+    };
 };

--- a/src/features/tracingEvents/at/index.test.ts
+++ b/src/features/tracingEvents/at/index.test.ts
@@ -52,7 +52,6 @@ const expectedState = {
     ci: '02024720',
     powerSavingMode: {
         requested: {
-            state: 'on',
             T3324: {
                 activated: true,
                 bitmask: '00000000',
@@ -81,7 +80,6 @@ const expectedState = {
                 activated: false,
                 bitmask: '11100000',
             },
-            state: 'off',
         },
     },
 

--- a/src/features/tracingEvents/at/parseAT.ts
+++ b/src/features/tracingEvents/at/parseAT.ts
@@ -75,7 +75,7 @@ export const parseAT = (packet: TraceEvent): ParsedPacket => {
         const status = getStatus(body);
         const payload = body ? removeStatusFromBody(body) : undefined;
         return {
-            command,
+            command: command != null ? command.toUpperCase() : command,
             payload: payload || undefined,
             requestType: startsWithAt
                 ? operatorToRequestType(operator)

--- a/src/features/tracingEvents/types.ts
+++ b/src/features/tracingEvents/types.ts
@@ -291,7 +291,6 @@ export type GeneratedPowerSavingModeEntries = {
     [timer: TimerKey]: PowerSavingModeValues;
 };
 export type PowerSavingModeEntries = {
-    state?: 'on' | 'off';
     // Also known as 'Active Time'
     T3324?: PowerSavingModeValues;
     // Also known as Periodic TAU (Legacy)

--- a/src/utils/powerSavingMode.test.ts
+++ b/src/utils/powerSavingMode.test.ts
@@ -6,9 +6,9 @@
 
 import { PowerSavingModeValues } from '../features/tracingEvents/types';
 import {
+    ACTIVE_TIMER_BASE_VALUES,
     parsePowerSavingMode,
-    TAU_ACTIVE_TIMER_BASE_VALUES,
-    TAU_SLEEP_INTERVAL_BASE_VALUES,
+    PERIODIC_TAU_BASE_VALUES,
     TAU_TYPES,
 } from './powerSavingMode';
 
@@ -20,7 +20,7 @@ const deactivatedTimer: PowerSavingModeValues = {
 test('parsePowerSavingMode for T3412Extended (Periodic Tau)', () => {
     const valueBitmask = '01010';
     const valueDecimal = 10;
-    Object.entries(TAU_SLEEP_INTERVAL_BASE_VALUES).forEach(
+    Object.entries(PERIODIC_TAU_BASE_VALUES).forEach(
         ([multiplyerBitmask, multiplyerDecimalValue]) => {
             const expectedSeconds = multiplyerDecimalValue * valueDecimal;
             const bitmask = `${multiplyerBitmask}${valueBitmask}`;
@@ -46,7 +46,7 @@ test('parsePowerSavingMode for T3412Extended (Periodic Tau)', () => {
 test('parsePowerSavingMode for T3324 (ActiveTimer)', () => {
     const valueBitmask = '01010';
     const valueDecimal = 10;
-    Object.entries(TAU_ACTIVE_TIMER_BASE_VALUES).forEach(
+    Object.entries(ACTIVE_TIMER_BASE_VALUES).forEach(
         ([multiplyerBitmask, multiplyerDecimalValue]) => {
             const expectedSeconds = multiplyerDecimalValue * valueDecimal;
             const bitmask = `${multiplyerBitmask}${valueBitmask}`;

--- a/src/utils/powerSavingMode.ts
+++ b/src/utils/powerSavingMode.ts
@@ -22,7 +22,7 @@ export enum TAU_TYPES {
 const ONE_MINUTE = 60;
 const ONE_HOUR = ONE_MINUTE * 60;
 
-export const TAU_SLEEP_INTERVAL_BASE_VALUES: { [index: string]: number } = {
+export const PERIODIC_TAU_BASE_VALUES: { [index: string]: number } = {
     /*
      * Multiplyer of 000 means timer is Deactivated
      * And, a value of 0 effectively means that the timer is deactivated.
@@ -36,7 +36,7 @@ export const TAU_SLEEP_INTERVAL_BASE_VALUES: { [index: string]: number } = {
     '110': ONE_HOUR * 320,
     '111': 0, // Deactivated
 };
-export const TAU_ACTIVE_TIMER_BASE_VALUES: { [index: string]: number } = {
+export const ACTIVE_TIMER_BASE_VALUES: { [index: string]: number } = {
     /*
      * Multiplyer of 000 means it's Deactivated
      * However, a value of 0 is allowed when activeTimer is activated.
@@ -73,17 +73,15 @@ export const parseTAUByteToSeconds = (byteString: string, type: TAU_TYPES) => {
 
     if (
         type === TAU_TYPES.SLEEP_INTERVAL &&
-        TAU_MULTIPLYER in TAU_SLEEP_INTERVAL_BASE_VALUES
+        TAU_MULTIPLYER in PERIODIC_TAU_BASE_VALUES
     )
-        return (
-            TAU_SLEEP_INTERVAL_BASE_VALUES[TAU_MULTIPLYER] * TAU_BINARY_VALUE
-        );
+        return PERIODIC_TAU_BASE_VALUES[TAU_MULTIPLYER] * TAU_BINARY_VALUE;
 
     if (
         type === TAU_TYPES.ACTIVE_TIMER &&
-        TAU_MULTIPLYER in TAU_ACTIVE_TIMER_BASE_VALUES
+        TAU_MULTIPLYER in ACTIVE_TIMER_BASE_VALUES
     )
-        return TAU_ACTIVE_TIMER_BASE_VALUES[TAU_MULTIPLYER] * TAU_BINARY_VALUE;
+        return ACTIVE_TIMER_BASE_VALUES[TAU_MULTIPLYER] * TAU_BINARY_VALUE;
 
     // Invalid values: deactivated timer returned
     logger.debug(


### PR DESCRIPTION
#### Motivation

This PR aims to revise the two different methods of turning off PSM using the AT command `AT+CPSMS`.

The idea is that if we have detected `requested` PSM values, we store those in a local variable for the given trace. And if PSM is disabled using `AT+CPSMS=0`, and then activated again using `AT+CPSMS=1`, we simply display that the requested values are those stored `requested` values.

In contrast, if `AT+CPSMS=` is used to disable PSM, then we remove the `requested` values we have stored, and set them to the default values instead.

#### Additional Note

When using `AT+CPSMS`, we don't necessarily have the history of what has been requested before, it all depends on when the trace started. It may for example be that the device have been running, and the modem have stored the `request` parameters before the trace have started. Then, when we read `AT+CPSMS=1` from the trace, we assume that the default parameters are used. Then the network `provided` values may differ from the `requested` values, even though they may have been the same.

This is something that would have been possible to fix if we read the network traffic, in addition to the AT traffic.
