### PR TITLE
Add event notifications to device card

### DIFF
--- a/resources/docs/dashboardFields.ts
+++ b/resources/docs/dashboardFields.ts
@@ -294,6 +294,44 @@ register to.
                 'If set before modem activation this configures an extra reduction of 0.5 or 1 dB to the maximum transmission power on NB-IOT. The command is Nordic-proprietary, see the documentation at the following link for more information.',
             commands: ['AT%XEMPR'] as const,
         },
+        'ME OVERHEATED': {
+            title: 'Mobile Equipment (ME) Overheated',
+            description: 'ME is overheated and therefore modem is deactivated',
+            commands: ['AT+CGEV', 'AT%MDMEV'] as const,
+        },
+        'ME BATTERY LOW': {
+            title: 'Mobile Equipment (ME) Battery Low',
+            description: 'ME battery is low and modem is deactivated',
+            commands: ['AT+CGEV', 'AT%MDMEV'] as const,
+        },
+        'SEARCH STATUS 1': {
+            description: `SEARCH STATUS 1 indicates light search performed. This event gives the application a chance to
+            stop the modem from using more power on searching networks from possibly weaker radio condition.
+            Before sending this event, the modem searches the cells based on previous cell history, measures the
+            radio conditions, and makes assumptions on where networks might be deployed. This event means that
+            the modem has not found a network that it could select based on the 3GPP network selection rules
+            from those locations. It does not mean that there are no networks to be found in the area. The modem
+            continues more thorough searches automatically after sending this status. The modem can be deactivated,
+            for example, with +CFUN=4, to stop it from using more power on the search.`,
+            commands: ['AT%MDMEV'] as const,
+        },
+        'SEARCH STATUS 2': {
+            description: `SEARCH STATUS 2 indicates search performed. The modem has found a network that it can select
+            according to the 3GPP network selection rules or all frequencies have been scanned and a suitable cell
+            has not been found. In the latter case, the modem enters normal limited service state functionality and
+            performs scans for service periodically.`,
+            commands: ['AT%MDMEV'] as const,
+        },
+        'RESET LOOP': {
+            description: `RESET LOOP indicates that the modem restricts Attach attempts for the next 30 minutes. The timer
+            does not run when the modem has no power or while it stays in the reset loop. The modem counts all the resets where the modem is not gracefully deinitialized with +CFUN=0.
+
+            Reset Loop is activated if:
+            For mfw v1.3.0: more than five resets
+            For mfw >= v1.3.1: more than seven resets
+            `,
+            commands: ['AT%MDMEV'] as const,
+        },
     },
     Sim: {
         'UICC STATUS': {

--- a/src/features/dashboard/Cards/DashboardCard.css
+++ b/src/features/dashboard/Cards/DashboardCard.css
@@ -21,3 +21,12 @@
         background-color: white;
     }
 }
+
+@keyframes valueChangedWithWarning {
+    from {
+        background-color: #c8e6c9;
+    }
+    to {
+        background-color: var(--color-orange);
+    }
+}

--- a/src/features/dashboard/Cards/DashboardCard.css
+++ b/src/features/dashboard/Cards/DashboardCard.css
@@ -21,12 +21,3 @@
         background-color: white;
     }
 }
-
-@keyframes valueChangedWithWarning {
-    from {
-        background-color: #c8e6c9;
-    }
-    to {
-        background-color: var(--color-orange);
-    }
-}

--- a/src/features/dashboard/Cards/DashboardCard.tsx
+++ b/src/features/dashboard/Cards/DashboardCard.tsx
@@ -35,6 +35,7 @@ import './DashboardCard.css';
 export type DashboardCardFields = Record<string, DashboardCardField>;
 export type DashboardCardField = {
     value: string | number;
+    conditionalStyle?: React.CSSProperties;
 };
 
 type DashboardCard = {
@@ -78,6 +79,7 @@ export default ({
                         fieldKey={fieldKey}
                         value={fieldValues.value}
                         title={title}
+                        style={fieldValues.conditionalStyle}
                     />
                 </li>
             ))}
@@ -89,11 +91,12 @@ type CardEntry = {
     fieldKey: string;
     value: string | number;
     title: string;
+    style?: React.CSSProperties;
 };
 
 const isCopiable = (value: string | number) => value !== 'Unknown';
 
-const CardEntry = ({ fieldKey, value, title }: CardEntry) => {
+const CardEntry = ({ fieldKey, value, title, style }: CardEntry) => {
     const dispatch = useDispatch();
     const [showTooltip, setShowTooltip] = useState(false);
 
@@ -102,6 +105,9 @@ const CardEntry = ({ fieldKey, value, title }: CardEntry) => {
     const oldValue = useRef<string | number | null>(null);
 
     useEffect(() => {
+        if (style?.animation) {
+            return;
+        }
         if (
             value !== oldValue.current &&
             oldValue.current &&
@@ -113,7 +119,7 @@ const CardEntry = ({ fieldKey, value, title }: CardEntry) => {
             );
         }
         oldValue.current = value;
-    }, [value]);
+    }, [style?.animation, value]);
 
     const showCopiable = (copiable: boolean) => {
         if (copiable) {
@@ -136,6 +142,7 @@ const CardEntry = ({ fieldKey, value, title }: CardEntry) => {
         <div
             role="textbox"
             tabIndex={0}
+            style={style}
             className="card-entry"
             onMouseEnter={() => setShowTooltip(true)}
             onMouseLeave={() => setShowTooltip(false)}
@@ -197,7 +204,7 @@ const CardTooltip = ({ fieldKey, title, setShowTooltip }: CardTooltip) => {
         title: titleFromDocumentation,
     } = getDashboardFieldDocumentation(title, fieldKey);
 
-    const tooltipTitle = titleFromDocumentation || title;
+    const tooltipTitle = titleFromDocumentation ?? fieldKey;
 
     return (
         <Tooltip id={`tooltip-${fieldKey}`}>

--- a/src/features/dashboard/Cards/DashboardCard.tsx
+++ b/src/features/dashboard/Cards/DashboardCard.tsx
@@ -74,7 +74,7 @@ export default ({
             }
         >
             {Object.entries(fields).map(([fieldKey, fieldValues]) => (
-                <li key={fieldKey}>
+                <li key={fieldKey} style={{ padding: 0 }}>
                     <CardEntry
                         fieldKey={fieldKey}
                         value={fieldValues.value}
@@ -141,18 +141,16 @@ const CardEntry = ({ fieldKey, value, title, style }: CardEntry) => {
     return (
         <div
             role="textbox"
+            ref={fieldRef}
             tabIndex={0}
-            style={style}
+            style={{ ...style, padding: '2px 4px' }}
             className="card-entry"
             onMouseEnter={() => setShowTooltip(true)}
             onMouseLeave={() => setShowTooltip(false)}
             onFocus={() => setShowTooltip(true)}
             onBlur={() => setShowTooltip(false)}
         >
-            <div
-                ref={fieldRef}
-                className="w-100 d-flex justify-content-between"
-            >
+            <div className="w-100 d-flex justify-content-between">
                 <p>
                     <b>{fieldKey}</b>
                 </p>

--- a/src/features/dashboard/Cards/Device.tsx
+++ b/src/features/dashboard/Cards/Device.tsx
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { colors } from 'pc-nrfconnect-shared';
 
 import { FunctionalMode } from '../../tracingEvents/at/commandProcessors/functionMode';
 import { Mode } from '../../tracingEvents/at/commandProcessors/TXPowerReduction';
@@ -35,6 +36,11 @@ export default () => {
         // xModemTrace
         xModemTraceOperation,
         xModemTraceSetID,
+        meOverheated,
+        meBatteryLow,
+        searchStatus1,
+        searchStatus2,
+        resetLoop,
     } = useSelector(getDashboardState);
 
     const haveRecievedModemSupport = !(
@@ -97,6 +103,26 @@ export default () => {
         },
         'NB-IOT TX REDUCTION': {
             value: formatMode(nbiotTXReduction) ?? 'Unknown',
+        },
+        'ME OVERHEATED': {
+            value: meOverheated ? 'Yes' : 'No',
+            conditionalStyle: addWarningStyle(meOverheated),
+        },
+        'ME BATTERY LOW': {
+            value: meBatteryLow ? 'Yes' : 'No',
+            conditionalStyle: addWarningStyle(meBatteryLow),
+        },
+        'SEARCH STATUS 1': {
+            value: searchStatus1 ? 'Yes' : 'No',
+            conditionalStyle: addWarningStyle(searchStatus1),
+        },
+        'SEARCH STATUS 2': {
+            value: searchStatus2 ? 'Yes' : 'No',
+            conditionalStyle: addWarningStyle(searchStatus2),
+        },
+        'RESET LOOP': {
+            value: resetLoop ? 'Yes' : 'No',
+            conditionalStyle: addWarningStyle(resetLoop),
         },
     };
     return (
@@ -191,3 +217,12 @@ const parsePreferredBearer = (preferred: number) => {
             return 'Unknown';
     }
 };
+
+const addWarningStyle = (active?: boolean): React.CSSProperties =>
+    active
+        ? {
+              color: colors.white,
+              backgroundColor: colors.orange,
+              animation: '5s valueChangedWithWarning',
+          }
+        : {};

--- a/src/features/dashboard/Cards/Device.tsx
+++ b/src/features/dashboard/Cards/Device.tsx
@@ -114,11 +114,9 @@ export default () => {
         },
         'SEARCH STATUS 1': {
             value: searchStatus1 ? 'Yes' : 'No',
-            conditionalStyle: addWarningStyle(searchStatus1),
         },
         'SEARCH STATUS 2': {
             value: searchStatus2 ? 'Yes' : 'No',
-            conditionalStyle: addWarningStyle(searchStatus2),
         },
         'RESET LOOP': {
             value: resetLoop ? 'Yes' : 'No',
@@ -221,8 +219,8 @@ const parsePreferredBearer = (preferred: number) => {
 const addWarningStyle = (active?: boolean): React.CSSProperties =>
     active
         ? {
-              color: colors.white,
-              backgroundColor: colors.orange,
-              animation: '5s valueChangedWithWarning',
+              // orange200
+              backgroundColor: '#FFCC80',
+              animation: 'unset',
           }
         : {};

--- a/src/features/tracingEvents/at/commandProcessors/modemDomainEventNotification.test.ts
+++ b/src/features/tracingEvents/at/commandProcessors/modemDomainEventNotification.test.ts
@@ -16,9 +16,16 @@ test('AT%MDMEV updates the domainEvents state when notifications are received.',
         atPacket('%MDMEV: SEARCH STATUS 1'),
     ]);
 
-    expect(state.modemDomainEvents).toEqual([
-        'ME OVERHEATED',
-        'ME BATTERY LOW',
-        'SEARCH STATUS 1',
-    ]);
+    expect(state.meOverheated).toBe(true);
+    expect(state.meBatteryLow).toBe(true);
+    expect(state.searchStatus1).toBe(true);
+
+    state = convertPackets([atPacket('%MDMEV: ME OVERHEATED')], state);
+
+    expect(state.meOverheated).toBe(true);
+    expect(state.resetLoop).toBeUndefined();
+
+    state = convertPackets([atPacket('%MDMEV: RESET LOOP')], state);
+
+    expect(state.resetLoop).toBe(true);
 });

--- a/src/features/tracingEvents/at/commandProcessors/modemDomainEventNotification.ts
+++ b/src/features/tracingEvents/at/commandProcessors/modemDomainEventNotification.ts
@@ -6,7 +6,15 @@
 
 import type { Processor } from '..';
 import { RequestType } from '../parseAT';
-import { getNumber, parseStringValue } from '../utils';
+import { getNumber } from '../utils';
+
+const ModemDomainEvent = {
+    ME_OVERHEATED: 'ME OVERHEATED',
+    ME_BATTERY_LOW: 'ME BATTERY LOW',
+    SEARCH_STATUS_1: 'SEARCH STATUS 1',
+    SEARCH_STATUS_2: 'SEARCH STATUS 2',
+    RESET_LOOP: 'RESET LOOP',
+};
 
 let setNotification: 0 | 1;
 
@@ -36,17 +44,28 @@ export const processor: Processor<'%MDMEV'> = {
                 };
             }
         }
-        return state;
-    },
-    onNotification: (packet, state) => {
         if (packet.payload) {
-            const event = parseStringValue(packet.payload);
-            return {
-                ...state,
-                modemDomainEvents: state.modemDomainEvents
-                    ? [...state.modemDomainEvents, event]
-                    : [event],
-            };
+            const payload = packet.payload.trim();
+            if (payload.includes(ModemDomainEvent.ME_OVERHEATED)) {
+                state.meOverheated = true;
+                return state;
+            }
+            if (payload.includes(ModemDomainEvent.ME_BATTERY_LOW)) {
+                state.meBatteryLow = true;
+                return state;
+            }
+            if (payload.includes(ModemDomainEvent.SEARCH_STATUS_1)) {
+                state.searchStatus1 = true;
+                return state;
+            }
+            if (payload.includes(ModemDomainEvent.SEARCH_STATUS_2)) {
+                state.searchStatus2 = true;
+                return state;
+            }
+            if (payload.includes(ModemDomainEvent.RESET_LOOP)) {
+                state.resetLoop = true;
+                return state;
+            }
         }
         return state;
     },

--- a/src/features/tracingEvents/at/commandProcessors/packetDomainEvents.test.ts
+++ b/src/features/tracingEvents/at/commandProcessors/packetDomainEvents.test.ts
@@ -88,3 +88,20 @@ test('+CGEV: PDN deactivation removes the relevant AccessPointName', () => {
     state = convertPackets([atPacket('+CGEV: ME PDN DEACT 1')], state);
     expect(state.accessPointNames).toEqual({});
 });
+
+test('AT+CGEV updates overheated and batteryLow', () => {
+    let state = convertPackets([
+        atPacket('+CGEV: ME OVERHEATED\r\n'),
+        atPacket('+CGEV: ME BATTERY LOW'),
+    ]);
+    expect(state.meOverheated).toBe(true);
+    expect(state.meBatteryLow).toBe(true);
+
+    state = convertPackets([atPacket('+CGEV: ME OVERHEATED\r\n')]);
+    expect(state.meOverheated).toBe(true);
+    expect(state.meBatteryLow).toBeUndefined();
+
+    state = convertPackets([atPacket('+CGEV: ME BATTERY LOW\r\n')]);
+    expect(state.meOverheated).toBeUndefined();
+    expect(state.meBatteryLow).toBe(true);
+});

--- a/src/features/tracingEvents/at/commandProcessors/packetDomainEvents.ts
+++ b/src/features/tracingEvents/at/commandProcessors/packetDomainEvents.ts
@@ -38,7 +38,7 @@ export const processor: Processor<'+CGEV'> = {
             const payload = packet.payload.trim();
 
             // The 17 different cases based on the +CGEV notifactions
-            if (payload === PacketDomainEvent.NW_DETACH) {
+            if (payload.includes(PacketDomainEvent.NW_DETACH)) {
                 return {
                     ...state,
                     // networkStatus update?
@@ -47,7 +47,7 @@ export const processor: Processor<'+CGEV'> = {
                     accessPointNames: {},
                 };
             }
-            if (payload === PacketDomainEvent.ME_DETACH) {
+            if (payload.includes(PacketDomainEvent.ME_DETACH)) {
                 return {
                     ...state,
                     // networkStatus update?
@@ -56,12 +56,14 @@ export const processor: Processor<'+CGEV'> = {
                     accessPointNames: {},
                 };
             }
-            if (payload === PacketDomainEvent.ME_OVERHEATED) {
+            if (payload.includes(PacketDomainEvent.ME_OVERHEATED)) {
                 // TODO: should notify user about overheated
+                state.meOverheated = true;
                 return state;
             }
-            if (payload === PacketDomainEvent.ME_BATTERY_LOW) {
+            if (payload.includes(PacketDomainEvent.ME_BATTERY_LOW)) {
                 // TODO: should notify user about low battery
+                state.meBatteryLow = true;
                 return state;
             }
 

--- a/src/features/tracingEvents/at/index.test.ts
+++ b/src/features/tracingEvents/at/index.test.ts
@@ -93,7 +93,6 @@ const expectedState = {
     xModemTraceSetID: 2,
     rrcState: 1,
     mdmevNotification: 1,
-    modemDomainEvents: ['SEARCH STATUS 2'],
 
     networkTimeNotifications: 1,
     networkTimeNotification: {
@@ -110,6 +109,7 @@ const expectedState = {
             ipv4: '10.160.148.98',
         },
     },
+    searchStatus2: true,
 } as Partial<State>;
 
 test('Trace is read properly', () => {

--- a/src/features/tracingEvents/types.ts
+++ b/src/features/tracingEvents/types.ts
@@ -129,7 +129,11 @@ export interface State {
 
     // %MDMEV Modem Domain Event Notification
     mdmevNotification?: 0 | 1;
-    modemDomainEvents: string[];
+    meOverheated: boolean;
+    meBatteryLow: boolean;
+    searchStatus1: boolean;
+    searchStatus2: boolean;
+    resetLoop: boolean;
 
     // %CONNSTAT Connectivity Statistics state
     connStat?: {


### PR DESCRIPTION
### Adds the five domain notification fields in the Device card

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor/assets/34618612/551f80e0-92da-48a9-9b41-04ee0b0c2ce1)

### Adds an eye-catching background color

In order to communicate that that user should look into these notifications.

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor/assets/34618612/261e307e-1500-4eaa-b835-8fe4f4a0bab1)

