### PR TITLE
Improve signal quality values

### DIFF
--- a/resources/docs/dashboardFields.ts
+++ b/resources/docs/dashboardFields.ts
@@ -68,19 +68,24 @@ export const documentation: Documentation = {
             title: 'Reference Signal Received Power (RSRP)',
             description:
                 'The average power level received from a single reference signal in an LTE network.',
-            commands: ['AT%CESQ', 'AT%CONEVAL'] as const,
+            commands: [
+                'AT+CESQ',
+                'AT%CESQ',
+                'AT%CONEVAL',
+                'AT%XMONITOR',
+            ] as const,
         },
         RSRQ: {
             title: 'Reference Signal Received Quality (RSRQ)',
             description:
                 'The quality of a single reference signal received in an LTE network and calculated from RSRP.',
-            commands: ['AT%CESQ', 'AT%CONEVAL'] as const,
+            commands: ['AT+CESQ', 'AT%CESQ', 'AT%CONEVAL'] as const,
         },
         SNR: {
             title: 'Signal-to-Noise Ratio (SNR)',
             description:
                 'A measure of the quality of the cellular signal received by the mobile device. It represents the ratio of the signal power to the noise power in the received signal. A higher SNR value indicates a better-quality signal, while a lower value indicates a weaker or noisier signal.',
-            commands: ['AT%CESQ', 'AT%CONEVAL'] as const,
+            commands: ['AT%CESQ', 'AT%CONEVAL', 'AT%XMONITOR'] as const,
         },
         'NETWORK STATUS NOTIFICATIONS': {
             description:

--- a/src/features/dashboard/Cards/Device.tsx
+++ b/src/features/dashboard/Cards/Device.tsx
@@ -6,7 +6,6 @@
 
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { colors } from 'pc-nrfconnect-shared';
 
 import { FunctionalMode } from '../../tracingEvents/at/commandProcessors/functionMode';
 import { Mode } from '../../tracingEvents/at/commandProcessors/TXPowerReduction';

--- a/src/features/dashboard/Cards/LTENetwork.tsx
+++ b/src/features/dashboard/Cards/LTENetwork.tsx
@@ -63,19 +63,13 @@ export default () => {
             value: earfcn == null || Number.isNaN(earfcn) ? 'Unknown' : earfcn,
         },
         RSRP: {
-            value: signalQuality?.rsrp_decibel
-                ? `${signalQuality?.rsrp_decibel} dBm`
-                : 'Unknown',
+            value: parseRsrp(signalQuality?.rsrp, signalQuality?.rsrp_decibel),
         },
         RSRQ: {
-            value: signalQuality?.rsrq_decibel
-                ? `${signalQuality?.rsrq_decibel} dB`
-                : 'Unknown',
+            value: parseRsrq(signalQuality?.rsrq, signalQuality?.rsrq_decibel),
         },
         SNR: {
-            value: signalQuality?.snr_decibel
-                ? `${signalQuality?.snr_decibel} dB`
-                : 'Unknown',
+            value: parseSnr(signalQuality?.snr, signalQuality?.snr_decibel),
         },
         'EPS NETWORK REGISTRATION STATUS': {
             value: networkStatus ?? 'Unknown',
@@ -192,4 +186,76 @@ const parseCellId = (id?: string) => {
     }
 
     return 'Unknown';
+};
+
+const parseRsrp = (rsrp?: number, rsrpDecibel?: number) => {
+    if (rsrp == null) return 'Unknown';
+
+    if (rsrp === 255) {
+        return 'Not known or not detectable (255)';
+    }
+
+    if (rsrpDecibel != null) {
+        let quality = '';
+        if (rsrpDecibel >= -84) {
+            quality = 'Excellent';
+        } else if (rsrpDecibel <= -85 && rsrpDecibel >= -102) {
+            quality = 'Good';
+        } else if (rsrpDecibel <= -103 && rsrpDecibel >= -111) {
+            quality = 'Fair';
+        } else if (rsrpDecibel < -111) {
+            quality = 'Poor';
+        }
+        return `${quality} (${rsrpDecibel} dBm)`;
+    }
+
+    return 'Unknown' as never;
+};
+
+const parseRsrq = (rsrq?: number, rsrqDecibel?: number) => {
+    if (rsrq == null) return 'Unknown';
+
+    if (rsrq === 255) {
+        return 'Not known or not detectable (255)';
+    }
+
+    if (rsrqDecibel != null) {
+        let quality = '';
+        if (rsrqDecibel >= -4) {
+            quality = 'Excellent';
+        } else if (rsrqDecibel <= -5 && rsrqDecibel >= -9) {
+            quality = 'Good';
+        } else if (rsrqDecibel <= -9 && rsrqDecibel >= -12) {
+            quality = 'Fair';
+        } else if (rsrqDecibel < -12) {
+            quality = 'Poor';
+        }
+        return `${quality} (${rsrqDecibel} dB)`;
+    }
+
+    return 'Unknown' as never;
+};
+
+const parseSnr = (snr?: number, snrDecibel?: number) => {
+    if (snr == null) return 'Unknown';
+
+    if (snr === 255) {
+        return 'Not known or not detectable (255)';
+    }
+
+    if (snrDecibel != null) {
+        let quality = '';
+        if (snrDecibel >= 12.5) {
+            quality = 'Excellent';
+        } else if (snrDecibel >= 10 && snrDecibel <= 12.5) {
+            quality = 'Good';
+        } else if (snrDecibel >= 7 && snrDecibel <= 10) {
+            quality = 'Fair';
+        } else if (snrDecibel < 7) {
+            quality = 'Poor';
+        }
+        return `${quality} (${snrDecibel} dB)`;
+    }
+
+    return 'Unknown' as never;
 };

--- a/src/features/tracingEvents/at/commandProcessors/evaluatingConnectionParameters.test.ts
+++ b/src/features/tracingEvents/at/commandProcessors/evaluatingConnectionParameters.test.ts
@@ -6,6 +6,36 @@
 import { State } from '../../types';
 import { atPacket, convertPackets } from '../testUtils';
 
+test('AT%CONEVAL with rsrp, rsrq, snr equal to 255 yields undefined decibel values', () => {
+    const state = convertPackets([
+        atPacket('AT%CONEVAL'),
+        atPacket(
+            '%CONEVAL: 0,1,5,255,255,255,"011B0780”,"26295",7,1575,3,1,1,23,16,32,130\r\nOK\r\n'
+        ),
+    ]);
+
+    expect(state.signalQuality?.rsrp).toBe(255);
+    expect(state.signalQuality?.rsrp_decibel).toBeUndefined();
+    expect(state.signalQuality?.rsrq).toBe(255);
+    expect(state.signalQuality?.rsrq_decibel).toBeUndefined();
+    expect(state.signalQuality?.snr).toBe(255);
+    expect(state.signalQuality?.snr_decibel).toBeUndefined();
+});
+
+test('AT%CONEVAL gives appropriate partial state after evaluation response.', () => {
+    const result = convertPackets(setCommands.commands);
+
+    Object.entries(setCommands.expected).forEach(([key, value]) => {
+        const actual = result[key as keyof State];
+        if (typeof actual === 'object') {
+            expect(actual).toEqual(value);
+        } else {
+            expect(actual).toBe(value);
+        }
+    });
+    // expect(result).toEqual(setCommands.expected);
+});
+
 const setCommands = {
     commands: [
         atPacket('AT%CONEVAL'),
@@ -38,17 +68,3 @@ const setCommands = {
         conevalDLPathLoss: 130,
     } as Partial<State>,
 };
-
-test('AT%CONEVAL gives appropriate partial state after evaluation response.', () => {
-    const result = convertPackets(setCommands.commands);
-
-    Object.entries(setCommands.expected).forEach(([key, value]) => {
-        const actual = result[key as keyof State];
-        if (typeof actual === 'object') {
-            expect(actual).toEqual(value);
-        } else {
-            expect(actual).toBe(value);
-        }
-    });
-    // expect(result).toEqual(setCommands.expected);
-});

--- a/src/features/tracingEvents/at/commandProcessors/evaluatingConnectionParameters.ts
+++ b/src/features/tracingEvents/at/commandProcessors/evaluatingConnectionParameters.ts
@@ -9,6 +9,7 @@ import {
     ConnectionEvaluationResult,
     CoverageEnhancementLevel,
     RRCState,
+    SignalQuality,
     TAUTriggered,
 } from '../../types';
 import type { Processor } from '..';
@@ -37,18 +38,7 @@ export const processor: Processor<'%CONEVAL'> = {
                     ),
                     signalQuality: {
                         ...state.signalQuality,
-                        rsrp: rsrp ?? state.signalQuality?.rsrp,
-                        rsrp_decibel: rsrp
-                            ? rsrp - 140
-                            : state.signalQuality?.rsrp_decibel,
-                        rsrq: rsrq ?? state.signalQuality?.rsrq,
-                        rsrq_decibel: rsrq
-                            ? rsrq / 2 - 19.5
-                            : state.signalQuality?.rsrq_decibel,
-                        snr: snr ?? state.signalQuality?.snr,
-                        snr_decibel: snr
-                            ? snr - 24
-                            : state.signalQuality?.snr_decibel,
+                        ...parseSignalQuality(rsrp, rsrq, snr),
                     },
                     cellID: parsedPayload[6],
                     plmn: parsedPayload[7],
@@ -134,4 +124,36 @@ const validateNumberValue = (value: string): number | undefined => {
     const numberValue = Number.parseInt(value, 10);
     if (!Number.isNaN(numberValue)) return numberValue;
     return undefined as never;
+};
+
+const parseSignalQuality = (
+    rsrp?: number,
+    rsrq?: number,
+    snr?: number
+): SignalQuality => {
+    const result: SignalQuality = {
+        rsrp,
+        rsrq,
+        snr,
+    };
+
+    if (rsrp && rsrp !== 255) {
+        result.rsrp_decibel = rsrp - 140;
+    } else if (rsrp === 255) {
+        result.rsrp_decibel = undefined;
+    }
+
+    if (rsrq && rsrq !== 255) {
+        result.rsrq_decibel = rsrq / 2 - 19.5;
+    } else if (rsrq === 255) {
+        result.rsrq_decibel = undefined;
+    }
+
+    if (snr && snr !== 255) {
+        result.snr_decibel = snr - 24;
+    } else if (snr === 255) {
+        result.snr_decibel = undefined;
+    }
+
+    return result;
 };

--- a/src/features/tracingEvents/at/commandProcessors/extendedSignalQuality.test.ts
+++ b/src/features/tracingEvents/at/commandProcessors/extendedSignalQuality.test.ts
@@ -32,3 +32,14 @@ test('CESQ read commands work as expected', () => {
         ).toEqual(test.expected);
     });
 });
+
+test('CESQ rsrq and rsrp with index 255 do not yield a decibel value', () => {
+    const state = convertPackets([
+        atPacket('AT+CESQ'),
+        atPacket('+CESQ: 255,255,255,255,255,255\r\nOK\r\n'),
+    ]);
+    expect(state.signalQuality?.rsrq).toBe(255);
+    expect(state.signalQuality?.rsrq_decibel).toBeUndefined();
+    expect(state.signalQuality?.rsrp).toBe(255);
+    expect(state.signalQuality?.rsrp_decibel).toBeUndefined();
+});

--- a/src/features/tracingEvents/at/commandProcessors/extendedSignalQuality.ts
+++ b/src/features/tracingEvents/at/commandProcessors/extendedSignalQuality.ts
@@ -22,15 +22,18 @@ export const processor: Processor<'+CESQ'> = {
             packet.payload
         ) {
             const responseArray = getNumberArray(packet.payload);
+            const [, , , , rsrq, rsrp] = responseArray;
             return {
                 ...state,
                 signalQuality: {
                     ...state.signalQuality,
                     // Unused,Unused,Unused,Unused,rsrq,rsrp
-                    rsrq: responseArray[4],
-                    rsrq_decibel: responseArray[4] / 2 - 19.5,
-                    rsrp: responseArray[5],
-                    rsrp_decibel: responseArray[5] - 140,
+                    rsrq,
+                    rsrq_decibel:
+                        rsrq !== 255 ? responseArray[4] / 2 - 19.5 : undefined,
+                    rsrp,
+                    rsrp_decibel:
+                        rsrp !== 255 ? responseArray[5] - 140 : undefined,
                 },
             };
         }

--- a/src/features/tracingEvents/at/commandProcessors/modemParameters.test.ts
+++ b/src/features/tracingEvents/at/commandProcessors/modemParameters.test.ts
@@ -7,6 +7,18 @@
 import { State } from '../../types';
 import { atPacket, convertPackets } from '../testUtils';
 
+test('%XMONTIOR rsrp and snr 255 yield undefined decibel', () => {
+    const state = convertPackets([
+        atPacket(
+            '%XMONITOR: 5,"Telia N@","Telia N@","24202","0901",7,20,"02024720",428,6300,255,255,"","00000010","00100010","01001001"\r\nOK'
+        ),
+    ]);
+    expect(state.signalQuality?.rsrp).toBe(255);
+    expect(state.signalQuality?.rsrp_decibel).toBeUndefined();
+    expect(state.signalQuality?.snr).toBe(255);
+    expect(state.signalQuality?.snr_decibel).toBeUndefined();
+});
+
 test('%XMONITOR packet with mfw version >= v1.2.x', () => {
     const state = convertPackets([
         modernModemVersionPacket.command,

--- a/src/features/tracingEvents/at/commandProcessors/signalQualityNotification.test.ts
+++ b/src/features/tracingEvents/at/commandProcessors/signalQualityNotification.test.ts
@@ -39,18 +39,18 @@ const signalQualityNotifications = [
     // Mixes
     { packet: atPacket('%CESQ: 64,3,17,2'), result: [64, 3, -76, 17, 2, -11] },
 
-    // Unknown
+    // Unknown should yield undefined for decibel values
     {
         packet: atPacket('%CESQ: 255,255,255,255'),
-        result: [255, 255, 115, 255, 255, 108],
+        result: [255, 255, undefined, 255, 255, undefined],
     },
     {
         packet: atPacket('%CESQ: 255,255,17,2'),
-        result: [255, 255, 115, 17, 2, -11],
+        result: [255, 255, undefined, 17, 2, -11],
     },
     {
         packet: atPacket('%CESQ: 64,3,255, 255'),
-        result: [64, 3, -76, 255, 255, 108],
+        result: [64, 3, -76, 255, 255, undefined],
     },
 ];
 
@@ -126,4 +126,15 @@ test('%CESQ notification does set snr back to undefined', () => {
 
     expect(state.signalQuality?.snr).toBe(13);
     expect(state.signalQuality?.snr_decibel).toBe(13 - 24);
+});
+
+test('CESQ rsrq and rsrp with index 255 do not yield a decibel value', () => {
+    const state = convertPackets([
+        atPacket('AT+CESQ=1'),
+        atPacket('%CESQ: 255,255,255,255\r\nOK\r\n'),
+    ]);
+    expect(state.signalQuality?.rsrq).toBe(255);
+    expect(state.signalQuality?.rsrq_decibel).toBeUndefined();
+    expect(state.signalQuality?.rsrp).toBe(255);
+    expect(state.signalQuality?.rsrp_decibel).toBeUndefined();
 });

--- a/src/features/tracingEvents/at/commandProcessors/signalQualityNotification.ts
+++ b/src/features/tracingEvents/at/commandProcessors/signalQualityNotification.ts
@@ -54,23 +54,22 @@ export const processor: Processor<'%CESQ'> = {
     },
     onNotification: (packet, state) => {
         if (packet.payload) {
-            const signalQualityValues = getNumberArray(packet.payload);
+            const [rsrp, rsrpThresholdIndex, rsrq, rsrqThresholdIndex] =
+                getNumberArray(packet.payload);
 
-            if (signalQualityValues?.length === 4) {
-                return {
-                    ...state,
-                    signalQuality: {
-                        ...state.signalQuality,
-                        rsrp: signalQualityValues[0],
-                        rsrp_threshold_index: signalQualityValues[1],
-                        rsrp_decibel: signalQualityValues[0] - 140,
+            return {
+                ...state,
+                signalQuality: {
+                    ...state.signalQuality,
+                    rsrp,
+                    rsrp_threshold_index: rsrpThresholdIndex,
+                    rsrp_decibel: rsrp !== 255 ? rsrp - 140 : undefined,
 
-                        rsrq: signalQualityValues[2],
-                        rsrq_threshold_index: signalQualityValues[3],
-                        rsrq_decibel: signalQualityValues[2] / 2 - 19.5,
-                    },
-                };
-            }
+                    rsrq,
+                    rsrq_threshold_index: rsrqThresholdIndex,
+                    rsrq_decibel: rsrq !== 255 ? rsrq / 2 - 19.5 : undefined,
+                },
+            };
         }
         return state;
     },

--- a/src/features/tracingEvents/at/index.test.ts
+++ b/src/features/tracingEvents/at/index.test.ts
@@ -25,8 +25,8 @@ const expectedState = {
         rsrq_threshold_index: 1,
         rsrq_decibel: 11 / 2 - 19.5,
 
-        snr: 53,
-        snr_decibel: 53 - 24,
+        snr: 22,
+        snr_decibel: 22 - 24,
     },
     notifyPeriodicTAU: false,
     operatorFullName: 'Telia N@',

--- a/src/features/tracingEvents/types.ts
+++ b/src/features/tracingEvents/types.ts
@@ -100,16 +100,7 @@ export interface State {
     conevalResult?: ConnectionEvaluationResult;
     conevalEnergyEstimate?: ConevalEnergyEstimate;
     rrcState?: RRCState;
-    signalQuality?: {
-        rsrp?: number;
-        rsrp_threshold_index?: number;
-        rsrp_decibel?: number;
-        rsrq?: number;
-        rsrq_threshold_index?: number;
-        rsrq_decibel?: number;
-        snr?: number;
-        snr_decibel?: number;
-    };
+    signalQuality?: SignalQuality;
     cellID: string; // 4-byte E-UTRAN cell ID.
     physicalCellID?: number; // Integer [0, 503]
     earfcn?: number;
@@ -164,6 +155,17 @@ export interface eDRX {
     requestedValue?: string;
     nwProvidedValue?: string;
     pagingTimeWindow?: string;
+}
+
+export interface SignalQuality {
+    rsrp?: number;
+    rsrp_threshold_index?: number;
+    rsrp_decibel?: number;
+    rsrq?: number;
+    rsrq_threshold_index?: number;
+    rsrq_decibel?: number;
+    snr?: number;
+    snr_decibel?: number;
 }
 
 export enum PlmnStatus {


### PR DESCRIPTION
Fix: when the index for rsrp, rsrq, and snr, are 255, then the related decibel value should not be calculated, and in the GUI it should display 'Not known or not detectable', as per the documentation.

Feature: When decibel value is available, display the threshold values Excellent, Good, Fair, Poor, and the decibel value in parenthesis. Example (rsrp), 'Excellent (-80 dBm)'.

#### Default is still 'Unknown'

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor/assets/34618612/96733d1d-301c-42b5-a20e-49f176af7ae8)

#### All signal quality properties have decibel values

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor/assets/34618612/f21f5266-b23d-464c-94a1-1bc13e1ce07d)

#### When index is 255

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor/assets/34618612/fea8f96e-9940-4a37-b1b8-56bed7efe02e)

