### PR TITLE
Prepare release v1.0.3

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,11 +4,16 @@
 
 -   Option to auto-detect trace database when reading trace file.
 -   Option to deselect **Terminal Serial Port**.
--   Dashboard field values can be copied by clicking on the value.
+-   Dashboard field values can be copied by clicking on the value. The value
+    will have a blue background when it is possible to copy.
+-   Signal quality properties (RSRP, RSRQ, SNR) will show an indication of
+    Excellent, Good, Fair, or Bad signal strength when it is available.
 
 ### Fixed
 
 -   Programming sample could fail the first time programming an application.
+-   Signal quality properties (RSRP, RSRQ, SNR) showed incorrect decibel value
+    when it should have shown "Not known or not detectable".
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-cellularmonitor",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Capture and analyze modem traces",
     "displayName": "Cellular Monitor",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor",


### PR DESCRIPTION
This PR will prepare an internal release v1.0.3 to be tested.

## 1.0.3 - Unreleased

### Added

-   Option to auto-detect trace database when reading trace file.
-   Option to deselect **Terminal Serial Port**.
-   Dashboard field values can be copied by clicking on the value. The value
    will have a blue background when it is possible to copy.
-   Signal quality properties (RSRP, RSRQ, SNR) will show an indication of
    Excellent, Good, Fair, or Bad signal strength when it is available.

### Fixed

-   Programming sample could fail the first time programming an application.
-   Signal quality properties (RSRP, RSRQ, SNR) showed incorrect decibel value
    when it should have shown "Not known or not detectable".

### Changed

-   Renamed **Serial port trace capture** to **Modem trace serial port**.
-   When selected device only expose one serial port, the app will assume it
    will be used for modem trace. Hence, it will only auto-select serial port
    for the **Modem trace serial port**, and will not select anything for
    **Terminal serial port**.
-   Dashboard card title from Power Saving Mode to Power Saving Features.