### PR TITLE
Commands were not spaced properly

### DIFF
--- a/src/features/dashboard/Cards/DashboardCard.tsx
+++ b/src/features/dashboard/Cards/DashboardCard.tsx
@@ -207,11 +207,16 @@ const CardTooltip = ({ fieldKey, title, setShowTooltip }: CardTooltip) => {
     return (
         <Tooltip id={`tooltip-${fieldKey}`}>
             <div
-                className="card-tooltip"
+                style={{ backgroundColor: colors.gray900, padding: '8px 16px' }}
                 onMouseEnter={() => setShowTooltip(true)}
                 onMouseLeave={() => setShowTooltip(false)}
             >
-                <p className="font-weight-bold">{tooltipTitle}</p>
+                <p
+                    className="font-weight-bold"
+                    style={{ textTransform: 'uppercase', marginBottom: '8px' }}
+                >
+                    {tooltipTitle}
+                </p>
                 <Documentation description={description} />
                 <Commands commands={commands} />
             </div>
@@ -256,14 +261,26 @@ const Commands = ({
 
     return (
         <>
-            <p className="font-weight-bold">
+            <p className="font-weight-bold" style={{ marginBottom: '8px' }}>
                 RELATED {commands.length > 1 ? 'COMMANDS' : 'COMMAND'}
             </p>
             {commands.map((cmd, index) => (
-                <div key={`${cmd}`} className="mb-3">
-                    <p className="mb-0">{cmd}</p>
+                <div key={`${cmd}`}>
+                    <p style={{ marginBottom: 0 }}>{cmd}</p>
 
-                    <div className="d-flex">
+                    <div
+                        style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            marginBottom: '8px',
+                        }}
+                    >
+                        <IconAction
+                            action={() => openUrl(documentationMap[cmd])}
+                            label="Doc"
+                            icon={mdiTextBox}
+                            index={index}
+                        />
                         {isTracing &&
                         detectedAtHostLibrary &&
                         commandHasRecommeneded(cmd) ? (
@@ -279,12 +296,6 @@ const Commands = ({
                                 index={index}
                             />
                         ) : null}
-                        <IconAction
-                            action={() => openUrl(documentationMap[cmd])}
-                            label="Doc"
-                            icon={mdiTextBox}
-                            index={index}
-                        />
                     </div>
                 </div>
             ))}
@@ -313,6 +324,7 @@ const IconAction = ({
             color: colors.nordicBlue,
             display: 'flex',
             alignItems: 'center',
+            verticalAlign: 'middle',
         }}
         onClick={action}
         onKeyDown={event => {
@@ -322,7 +334,7 @@ const IconAction = ({
         }}
         className={className}
     >
-        <Icon className="mr-1" path={icon} size={0.6} />
+        <Icon className="mr-1" path={icon} size={0.7} />
         {label}
     </span>
 );

--- a/src/features/dashboard/Dashboard.scss
+++ b/src/features/dashboard/Dashboard.scss
@@ -108,11 +108,6 @@
     min-width: 240px;
 }
 
-.card-tooltip {
-    background: $gray-900;
-    padding: 8px 16px;
-}
-
 #tooltip {
     position: relative;
 }

--- a/src/features/dashboard/Dashboard.scss
+++ b/src/features/dashboard/Dashboard.scss
@@ -89,9 +89,9 @@
 
 .tooltip {
     div.arrow {
-        top: -6px;
-        width: 12px;
-        height: 12px;
+        top: -14px;
+        width: 20px;
+        height: 20px;
     }
     div.arrow::before {
         border-bottom-color: $gray-900;
@@ -104,7 +104,7 @@
 }
 
 .tooltip-inner {
-    padding-top: 16px;
+    padding-top: 14px;
     min-width: 240px;
 }
 


### PR DESCRIPTION
Also make content more compact, in order to show what content is grouped together. E.g. the vertical spacing between 'REALTED COMMAND' and the following content of commands were too big.

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor/assets/34618612/379b1b8e-8374-4f73-af64-924fb047c072)
