### PR TITLE
Fix/specify wireshark path

### DIFF
--- a/src/components/SidePanel/FileActions.tsx
+++ b/src/components/SidePanel/FileActions.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { Group, selectedDevice } from 'pc-nrfconnect-shared';
 
+import WiresharkWarning from '../../features/wireshark/WiresharkWarning';
 import { LoadTraceFile } from './LoadTraceFile';
 import TraceConverter from './Tracing/TraceConverter';
 
@@ -20,6 +21,7 @@ export default () => {
         <Group heading="FILE ACTIONS">
             <LoadTraceFile />
             <TraceConverter />
+            <WiresharkWarning />
         </Group>
     );
 };

--- a/src/components/SidePanel/Macros.tsx
+++ b/src/components/SidePanel/Macros.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Button, usageData } from 'pc-nrfconnect-shared';
+import { Button, selectedDevice, usageData } from 'pc-nrfconnect-shared';
 
 import { getTerminalSerialPort } from '../../features/terminal/serialPortSlice';
 import {
@@ -36,12 +36,13 @@ type Macro = {
 
 export const Macro = ({ commands, title }: Macro) => {
     const dispatch = useDispatch();
+    const device = useSelector(selectedDevice);
     const serialPort = useSelector(getTerminalSerialPort);
     const detectedAtHostLibrary = useSelector(getDetectedAtHostLibrary);
     const isTracing = useSelector(getIsTracing);
     const isSending = useSelector(getIsSendingATCommands);
 
-    if (serialPort != null) {
+    if (device != null && serialPort != null) {
         return (
             <Button
                 className="w-100"

--- a/src/components/SidePanel/Tracing/TraceFormatSelector.tsx
+++ b/src/components/SidePanel/Tracing/TraceFormatSelector.tsx
@@ -46,7 +46,7 @@ export default () => {
                 isToggled={selectedFormats.includes('raw')}
                 onToggle={toggle('raw')}
             />
-            <WiresharkWarning />
+            <WiresharkWarning onLiveTrace />
         </>
     );
 };

--- a/src/features/wireshark/WiresharkButton.tsx
+++ b/src/features/wireshark/WiresharkButton.tsx
@@ -19,10 +19,6 @@ import { getWiresharkPath, setWiresharkPath } from './wiresharkSlice';
 
 import './wireshark.scss';
 
-type WiresharkProps = {
-    extendedDescription?: boolean;
-};
-
 export const SelectWireshark: FC = ({ children }) => {
     const dispatch = useDispatch();
 
@@ -41,7 +37,7 @@ export const SelectWireshark: FC = ({ children }) => {
     );
 };
 
-export default ({ extendedDescription = false }: WiresharkProps) => {
+export default () => {
     const selectedWiresharkPath = useSelector(getWiresharkPath);
     const wiresharkPath = findWireshark(selectedWiresharkPath);
     const dispatch = useDispatch();
@@ -74,7 +70,6 @@ export default ({ extendedDescription = false }: WiresharkProps) => {
             ) : (
                 <>
                     <h6>Wireshark not detected</h6>
-                    {extendedDescription && <p> {extendedDescription}</p>}
                     <p>
                         <Button
                             variant="link"

--- a/src/features/wireshark/WiresharkButton.tsx
+++ b/src/features/wireshark/WiresharkButton.tsx
@@ -74,13 +74,8 @@ export default ({ extendedDescription = false }: WiresharkProps) => {
             ) : (
                 <>
                     <h6>Wireshark not detected</h6>
+                    {extendedDescription && <p> {extendedDescription}</p>}
                     <p>
-                        {extendedDescription && (
-                            <span>
-                                Wireshark is required for live streaming trace
-                                output.
-                            </span>
-                        )}
                         <Button
                             variant="link"
                             onClick={() => openUrl(WIRESHARK_DOWNLOAD_URL)}

--- a/src/features/wireshark/WiresharkWarning.tsx
+++ b/src/features/wireshark/WiresharkWarning.tsx
@@ -12,19 +12,21 @@ import { findWireshark } from './wireshark';
 import Wireshark from './WiresharkButton';
 import { getWiresharkPath } from './wiresharkSlice';
 
-export default () => {
+export default ({ onLiveTrace }: { onLiveTrace?: boolean }) => {
     const selectedWiresharkPath = useSelector(getWiresharkPath);
     const selectedTraceFormats = useSelector(getTraceFormats);
     const wiresharkPath = findWireshark(selectedWiresharkPath);
 
-    const showWiresharkWarning =
-        selectedTraceFormats.includes('live') && !wiresharkPath;
-    if (!showWiresharkWarning) return null;
+    if (wiresharkPath) return null;
+
+    if (onLiveTrace && !selectedTraceFormats.includes('live')) {
+        return null;
+    }
 
     return (
         <div className="wireshark-warning">
             <span className="mdi mdi-alert mdi-24px wireshark-warning-icon" />
-            <Wireshark extendedDescription />
+            <Wireshark />
         </div>
     );
 };


### PR DESCRIPTION
Now, when wireshark is not installed, or we do not properly locate it on the user's machine, the Side Panel immediately displays the option to install Wireshark or specify its location:

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor/assets/34618612/7f205d45-2d7b-463e-9f4d-f45e460d397a)

Additionally, the feature of only displaying the "warning" when device is selected and the option to open wireshark is selected is kept:

<div style="display:flex">

<img src="https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor/assets/34618612/f24682cd-fd34-428a-bc29-647a6f466e95" alt="with warning" style="width:32px">

<img src="https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor/assets/34618612/9cdae395-ca81-491a-b5a4-70a19727f9ea" alt="without warning" style="width:32px">

</div>


