### PR TITLE
Use shared with added IPC code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pc-nrfconnect-cellularmonitor",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pc-nrfconnect-cellularmonitor",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "bundleDependencies": [
                 "@nordicsemiconductor/nrf-monitor-lib-js"
             ],
@@ -22,7 +22,7 @@
                 "check-disk-space": "^2.1.0",
                 "jest-fetch-mock": "^3.0.3",
                 "mcc-mnc-list": "^1.1.11",
-                "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v62",
+                "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v76",
                 "pretty-bytes": "^5.6.0",
                 "react-chartjs-2": "^5.2.0",
                 "redux-mock-store": "^1.5.4",
@@ -37,6 +37,18 @@
             "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.2.0.tgz",
             "integrity": "sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA==",
             "dev": true
+        },
+        "node_modules/@alloc/quick-lru": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+            "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/@ampproject/remapping": {
             "version": "2.2.1",
@@ -1159,6 +1171,96 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
             "dev": true
+        },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dev": true,
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
         },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -2510,6 +2612,162 @@
                 "prop-types": "^15.7.2"
             }
         },
+        "node_modules/@microsoft/applicationinsights-analytics-js": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-3.0.2.tgz",
+            "integrity": "sha512-vrgEiT6cKC2Yb0Y6rCp9CXjFStlRZLI/IhIiBEGYaUfzoytLxUj6F/AizUDYBuNQfE+CTYe0jNyqf+RJgEMkJQ==",
+            "dev": true,
+            "dependencies": {
+                "@microsoft/applicationinsights-common": "3.0.2",
+                "@microsoft/applicationinsights-core-js": "3.0.2",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.2",
+                "@nevware21/ts-utils": ">= 0.9.5 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": "*"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-channel-js": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.0.2.tgz",
+            "integrity": "sha512-jDBNKbCHsJgmpv0CKNhJ/uN9ZphvfGdb93Svk+R4LjO8L3apNNMbDDPxBvXXi0uigRmA1TBcmyBG4IRKjabGhw==",
+            "dev": true,
+            "dependencies": {
+                "@microsoft/applicationinsights-common": "3.0.2",
+                "@microsoft/applicationinsights-core-js": "3.0.2",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.2",
+                "@nevware21/ts-async": ">= 0.2.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.9.5 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": "*"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-common": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.0.2.tgz",
+            "integrity": "sha512-y+WXWop+OVim954Cu1uyYMnNx6PWO8okHpZIQi/1YSqtqaYdtJVPv4P0AVzwJdohxzVfgzKvqj9nec/VWqE2Zg==",
+            "dev": true,
+            "dependencies": {
+                "@microsoft/applicationinsights-core-js": "3.0.2",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.2",
+                "@nevware21/ts-utils": ">= 0.9.5 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": "*"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-core-js": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.2.tgz",
+            "integrity": "sha512-WQhVhzlRlLDrQzn3OShCW/pL3BW5WC57t0oywSknX3q7lMzI3jDg7Ihh0iuIcNTzGCTbDkuqr4d6IjEDWIMtJQ==",
+            "dev": true,
+            "dependencies": {
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.2",
+                "@nevware21/ts-async": ">= 0.2.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.9.5 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": "*"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-dependencies-js": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-3.0.2.tgz",
+            "integrity": "sha512-b/YTonnbghg9DOFsLg4zdbYPafW8fPIzV+nZxfPPpxjA1LGvPhZz/zVx9YYWJg2RBXjojLQoJxLf1ro5eNGVig==",
+            "dev": true,
+            "dependencies": {
+                "@microsoft/applicationinsights-common": "3.0.2",
+                "@microsoft/applicationinsights-core-js": "3.0.2",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.2",
+                "@nevware21/ts-async": ">= 0.2.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.9.5 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": "*"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-properties-js": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-3.0.2.tgz",
+            "integrity": "sha512-PFqicp8q4Tc0hqfPjwfqKo12gEqTk1l4lMyUUIU7ugE1XOuDkZcMPha05KnZWKj+F4zQXJcetcAHoVkyoyCFQw==",
+            "dev": true,
+            "dependencies": {
+                "@microsoft/applicationinsights-common": "3.0.2",
+                "@microsoft/applicationinsights-core-js": "3.0.2",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.2",
+                "@nevware21/ts-utils": ">= 0.9.5 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": "*"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-shims": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+            "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+            "dev": true,
+            "dependencies": {
+                "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+            }
+        },
+        "node_modules/@microsoft/applicationinsights-web": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-3.0.2.tgz",
+            "integrity": "sha512-pf2zz/3mmGy1RoyaiLZwhHoE2mFZ+AWR3Zf7xPW7HjTG7dEE4BnovNyW3f9Eu6WWkcHUAHmS/ATzqvVlpB3W6A==",
+            "dev": true,
+            "dependencies": {
+                "@microsoft/applicationinsights-analytics-js": "3.0.2",
+                "@microsoft/applicationinsights-channel-js": "3.0.2",
+                "@microsoft/applicationinsights-common": "3.0.2",
+                "@microsoft/applicationinsights-core-js": "3.0.2",
+                "@microsoft/applicationinsights-dependencies-js": "3.0.2",
+                "@microsoft/applicationinsights-properties-js": "3.0.2",
+                "@microsoft/applicationinsights-shims": "3.0.1",
+                "@microsoft/dynamicproto-js": "^2.0.2",
+                "@nevware21/ts-async": ">= 0.2.4 < 2.x",
+                "@nevware21/ts-utils": ">= 0.9.5 < 2.x"
+            },
+            "peerDependencies": {
+                "tslib": "*"
+            }
+        },
+        "node_modules/@microsoft/dynamicproto-js": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.2.tgz",
+            "integrity": "sha512-MB8trWaFREpmb037k/d0bB7T2BP7Ai24w1e1tbz3ASLB0/lwphsq3Nq8S9I5AsI5vs4zAQT+SB5nC5/dLYTiOg==",
+            "dev": true,
+            "dependencies": {
+                "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+            }
+        },
+        "node_modules/@nevware21/ts-async": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.2.6.tgz",
+            "integrity": "sha512-NCUqEZSbsy7LVtKlUScd/eTst6djkWauLlzoIPVKCOxalEBdO8lrgNRIm4Xy68JNudNN5faqa2WA12X8m0BVhA==",
+            "dev": true,
+            "dependencies": {
+                "@nevware21/ts-utils": ">= 0.9.7 < 2.x"
+            },
+            "peerDependencies": {
+                "typescript": ">=1"
+            }
+        },
+        "node_modules/@nevware21/ts-utils": {
+            "version": "0.9.8",
+            "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.9.8.tgz",
+            "integrity": "sha512-kZ8s8hcn9jPVX/M7kSsBYrOGlHjqLahmxrG7QeKTk5paeVwfgKdvVCjj5Acb4UGb/ukU1G34U1Z3eb7bbVanyA==",
+            "dev": true,
+            "peerDependencies": {
+                "typescript": ">=1"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "dev": true,
@@ -2582,6 +2840,16 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "dev": true,
+            "optional": true,
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@pkgr/utils": {
@@ -3880,6 +4148,12 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/less": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/less/-/less-3.0.3.tgz",
+            "integrity": "sha512-1YXyYH83h6We1djyoUEqTlVyQtCfJAFXELSKW2ZRtjHD4hQ82CC4lvrv5D0l0FLcKBaiPbXyi3MpMsI9ZRgKsw==",
+            "dev": true
+        },
         "node_modules/@types/lodash": {
             "version": "4.14.191",
             "dev": true,
@@ -3983,6 +4257,16 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/sass": {
+            "version": "1.45.0",
+            "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.45.0.tgz",
+            "integrity": "sha512-jn7qwGFmJHwUSphV8zZneO3GmtlgLsmhs/LQyVvQbIIa+fzGMUiHI4HXJZL3FT8MJmgXWbLGiVVY7ElvHq6vDA==",
+            "deprecated": "This is a stub types definition. sass provides its own type definitions, so you do not need this installed.",
+            "dev": true,
+            "dependencies": {
+                "sass": "*"
+            }
+        },
         "node_modules/@types/scheduler": {
             "version": "0.16.3",
             "dev": true,
@@ -4004,6 +4288,15 @@
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
             "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
             "dev": true
+        },
+        "node_modules/@types/stylus": {
+            "version": "0.48.38",
+            "resolved": "https://registry.npmjs.org/@types/stylus/-/stylus-0.48.38.tgz",
+            "integrity": "sha512-B5otJekvD6XM8iTrnO6e2twoTY2tKL9VkL/57/2Lo4tv3EatbCaufdi68VVtn/h4yjO+HVvYEyrNQd0Lzj6riw==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/testing-library__jest-dom": {
             "version": "5.14.5",
@@ -4466,6 +4759,12 @@
                 "node": ">=4"
             }
         },
+        "node_modules/any-promise": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+            "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+            "dev": true
+        },
         "node_modules/anymatch": {
             "version": "3.1.3",
             "dev": true,
@@ -4712,18 +5011,6 @@
                 "safer-buffer": "~2.1.0"
             }
         },
-        "node_modules/assert": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-            "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-            "dev": true,
-            "dependencies": {
-                "es6-object-assign": "^1.1.0",
-                "is-nan": "^1.2.1",
-                "object-is": "^1.0.1",
-                "util": "^0.12.0"
-            }
-        },
         "node_modules/assert-plus": {
             "version": "1.0.0",
             "dev": true,
@@ -4764,6 +5051,39 @@
             "dev": true,
             "engines": {
                 "node": ">=10.12.0"
+            }
+        },
+        "node_modules/autoprefixer": {
+            "version": "10.4.14",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
+            "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+                }
+            ],
+            "dependencies": {
+                "browserslist": "^4.21.5",
+                "caniuse-lite": "^1.0.30001464",
+                "fraction.js": "^4.2.0",
+                "normalize-range": "^0.1.2",
+                "picocolors": "^1.0.0",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "bin": {
+                "autoprefixer": "bin/autoprefixer"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            },
+            "peerDependencies": {
+                "postcss": "^8.1.0"
             }
         },
         "node_modules/available-typed-arrays": {
@@ -5347,6 +5667,15 @@
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/camelcase-css": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+            "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/caniuse-lite": {
@@ -6511,6 +6840,12 @@
             "license": "MIT",
             "optional": true
         },
+        "node_modules/didyoumean": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+            "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+            "dev": true
+        },
         "node_modules/diff": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -6545,6 +6880,12 @@
             "version": "1.0.0",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/dlv": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+            "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+            "dev": true
         },
         "node_modules/doctrine": {
             "version": "3.0.0",
@@ -6671,6 +7012,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "dev": true
         },
         "node_modules/ecc-jsbn": {
             "version": "0.1.2",
@@ -7078,12 +7425,6 @@
                 "es6-symbol": "^3.1.1"
             }
         },
-        "node_modules/es6-object-assign": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-            "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
-            "dev": true
-        },
         "node_modules/es6-symbol": {
             "version": "3.1.3",
             "dev": true,
@@ -7142,6 +7483,75 @@
             },
             "peerDependencies": {
                 "esbuild": "^0.17.17"
+            }
+        },
+        "node_modules/esbuild-style-plugin": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/esbuild-style-plugin/-/esbuild-style-plugin-1.6.2.tgz",
+            "integrity": "sha512-aSzuIUwQTEVVy9gcE4xtXq8Cbq9RNDfJYZ3mYzWg6RJ8HoMydLT+LbGXYwL0DmgOt4eEg/4JrnNMMb02gXFutA==",
+            "dev": true,
+            "dependencies": {
+                "@types/less": "^3.0.3",
+                "@types/sass": "^1.43.1",
+                "@types/stylus": "^0.48.38",
+                "glob": "^10.2.2",
+                "postcss": "^8.4.23",
+                "postcss-modules": "^6.0.0"
+            }
+        },
+        "node_modules/esbuild-style-plugin/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/esbuild-style-plugin/node_modules/glob": {
+            "version": "10.3.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
+            "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
+            "dev": true,
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^2.0.3",
+                "minimatch": "^9.0.1",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+                "path-scurry": "^1.10.1"
+            },
+            "bin": {
+                "glob": "dist/cjs/src/bin.js"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/esbuild-style-plugin/node_modules/minimatch": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/esbuild-style-plugin/node_modules/minipass": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.2.tgz",
+            "integrity": "sha512-eL79dXrE1q9dBbDCLg7xfn/vl7MS4F1gvJAgjJrQli/jbQWdUttuVawphqpffoIYfRdq78LHx6GP4bU/EQ2ATA==",
+            "dev": true,
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
             }
         },
         "node_modules/escalade": {
@@ -8340,6 +8750,34 @@
                 "is-callable": "^1.1.3"
             }
         },
+        "node_modules/foreground-child": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+            "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.0",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/foreground-child/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/forever-agent": {
             "version": "0.6.1",
             "dev": true,
@@ -8368,6 +8806,19 @@
             "dev": true,
             "engines": {
                 "node": ">=0.4.x"
+            }
+        },
+        "node_modules/fraction.js": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
+            "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "type": "patreon",
+                "url": "https://www.patreon.com/infusion"
             }
         },
         "node_modules/fs": {
@@ -9660,8 +10111,9 @@
         },
         "node_modules/is-generator-function": {
             "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+            "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "has-tostringtag": "^1.0.0"
             },
@@ -9721,22 +10173,6 @@
             "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
             "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
             "dev": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-nan": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-            "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.0",
-                "define-properties": "^1.1.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -10107,6 +10543,24 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/jackspeak": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.2.tgz",
+            "integrity": "sha512-mgNtVv4vUuaKA97yxUHoA3+FkuhtxkjdXEWOyB/N76fjy0FjezEt34oy3epBtvCvS+7DyKwqCFWx/oJLV5+kCg==",
+            "dev": true,
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
             }
         },
         "node_modules/jest": {
@@ -12622,6 +13076,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/jiti": {
+            "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.19.1.tgz",
+            "integrity": "sha512-oVhqoRDaBXf7sjkll95LHVS6Myyyb1zaunVwk4Z0+WPSW4gjS0pl01zYKHScTuyEhQsFxV5L4DR5r+YqSyqyyg==",
+            "dev": true,
+            "bin": {
+                "jiti": "bin/jiti.js"
+            }
+        },
         "node_modules/jquery": {
             "version": "3.6.4",
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.4.tgz",
@@ -12978,6 +13441,15 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/lilconfig": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+            "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/lines-and-columns": {
@@ -13783,11 +14255,28 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/nanoid": {
-            "version": "3.3.4",
+        "node_modules/mz": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+            "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
             "dev": true,
-            "license": "MIT",
-            "peer": true,
+            "dependencies": {
+                "any-promise": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "thenify-all": "^1.0.0"
+            }
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+            "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -14278,6 +14767,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/normalize-range": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+            "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/normalize-url": {
             "version": "6.1.0",
             "dev": true,
@@ -14545,6 +15043,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/object-hash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+            "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/object-inspect": {
@@ -14924,6 +15431,40 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/path-scurry": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+            "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^9.1.1 || ^10.0.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-scurry/node_modules/lru-cache": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+            "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
+            "dev": true,
+            "engines": {
+                "node": "14 || >=16.14"
+            }
+        },
+        "node_modules/path-scurry/node_modules/minipass": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.2.tgz",
+            "integrity": "sha512-eL79dXrE1q9dBbDCLg7xfn/vl7MS4F1gvJAgjJrQli/jbQWdUttuVawphqpffoIYfRdq78LHx6GP4bU/EQ2ATA==",
+            "dev": true,
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
         "node_modules/path-type": {
             "version": "4.0.0",
             "dev": true,
@@ -14948,8 +15489,8 @@
             }
         },
         "node_modules/pc-nrfconnect-shared": {
-            "version": "62.0.0",
-            "resolved": "git+ssh://git@github.com/NordicSemiconductor/pc-nrfconnect-shared.git#bf027103ce1ad7bf6925bdd5072b319af7e6e3d6",
+            "version": "76.0.0",
+            "resolved": "git+ssh://git@github.com/NordicSemiconductor/pc-nrfconnect-shared.git#00749960bf38fb6ca3f8d21f51888e1ee83565e6",
             "dev": true,
             "hasInstallScript": true,
             "license": "ISC",
@@ -14958,6 +15499,7 @@
                 "@mdi/font": "7.2.96",
                 "@mdi/js": "^7.2.96",
                 "@mdi/react": "^1.6.1",
+                "@microsoft/applicationinsights-web": "^3.0.2",
                 "@reduxjs/toolkit": "1.9.3",
                 "@svgr/core": "^7.0.0",
                 "@svgr/plugin-jsx": "7.0.0",
@@ -14983,7 +15525,7 @@
                 "@typescript-eslint/eslint-plugin": "5.57.1",
                 "@typescript-eslint/parser": "5.57.1",
                 "adm-zip": "^0.5.5",
-                "assert": "2.0.0",
+                "autoprefixer": "10.4.14",
                 "bootstrap": "4.6.2",
                 "commander": "10.0.0",
                 "date-fns": "2.29.3",
@@ -14992,8 +15534,9 @@
                 "enzyme": "3.11.0",
                 "enzyme-adapter-react-16": "1.15.7",
                 "enzyme-to-json": "3.6.2",
-                "esbuild": "^0.17.18",
-                "esbuild-sass-plugin": "^2.9.0",
+                "esbuild": "0.17.18",
+                "esbuild-sass-plugin": "2.9.0",
+                "esbuild-style-plugin": "1.6.2",
                 "eslint": "8.37.0",
                 "eslint-config-airbnb": "19.0.4",
                 "eslint-config-prettier": "8.8.0",
@@ -15018,15 +15561,16 @@
                 "mousetrap": "1.6.5",
                 "npm-run-all2": "6.0.5",
                 "nrf-intel-hex": "^1.3.0",
+                "postcss": "8.4.24",
                 "postcss-modules": "^6.0.0",
                 "prettier": "2.8.8",
+                "prettier-plugin-tailwindcss": "^0.3.0",
                 "prettysize": "2.0.0",
                 "protobufjs": "^7.0.0",
                 "react": "16.14.0",
                 "react-bootstrap": "1.6.6",
                 "react-dom": "16.14.0",
                 "react-flip-toolkit": "7.0.17",
-                "react-ga": "2.7.0",
                 "react-markdown": "4.3.1",
                 "react-redux": "7.2.9",
                 "react-resize-detector": "6.7.8",
@@ -15040,6 +15584,7 @@
                 "serialport": "^10.5.0",
                 "shasum": "1.0.2",
                 "systeminformation": "5.17.12",
+                "tailwindcss": "3.3.2",
                 "ts-node": "10.9.1",
                 "typescript": "4.9.5",
                 "util": "0.12.5",
@@ -15132,7 +15677,6 @@
             "version": "2.3.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -15307,7 +15851,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.21",
+            "version": "8.4.24",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
+            "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
             "dev": true,
             "funding": [
                 {
@@ -15317,17 +15863,84 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "nanoid": "^3.3.4",
+                "nanoid": "^3.3.6",
                 "picocolors": "^1.0.0",
                 "source-map-js": "^1.0.2"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/postcss-import": {
+            "version": "15.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+            "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+            "dev": true,
+            "dependencies": {
+                "postcss-value-parser": "^4.0.0",
+                "read-cache": "^1.0.0",
+                "resolve": "^1.1.7"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.0.0"
+            }
+        },
+        "node_modules/postcss-js": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+            "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+            "dev": true,
+            "dependencies": {
+                "camelcase-css": "^2.0.1"
+            },
+            "engines": {
+                "node": "^12 || ^14 || >= 16"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/postcss/"
+            },
+            "peerDependencies": {
+                "postcss": "^8.4.21"
+            }
+        },
+        "node_modules/postcss-load-config": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.1.tgz",
+            "integrity": "sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==",
+            "dev": true,
+            "dependencies": {
+                "lilconfig": "^2.0.5",
+                "yaml": "^2.1.1"
+            },
+            "engines": {
+                "node": ">= 14"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/postcss/"
+            },
+            "peerDependencies": {
+                "postcss": ">=8.0.9",
+                "ts-node": ">=9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "postcss": {
+                    "optional": true
+                },
+                "ts-node": {
+                    "optional": true
+                }
             }
         },
         "node_modules/postcss-modules": {
@@ -15401,6 +16014,25 @@
             },
             "peerDependencies": {
                 "postcss": "^8.1.0"
+            }
+        },
+        "node_modules/postcss-nested": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
+            "integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
+            "dev": true,
+            "dependencies": {
+                "postcss-selector-parser": "^6.0.11"
+            },
+            "engines": {
+                "node": ">=12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/postcss/"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.14"
             }
         },
         "node_modules/postcss-selector-parser": {
@@ -15649,6 +16281,80 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/prettier-plugin-tailwindcss": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.3.0.tgz",
+            "integrity": "sha512-009/Xqdy7UmkcTBpwlq7jsViDqXAYSOMLDrHAdTMlVZOrKfM2o9Ci7EMWTMZ7SkKBFTG04UM9F9iM2+4i6boDA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.17.0"
+            },
+            "peerDependencies": {
+                "@ianvs/prettier-plugin-sort-imports": "*",
+                "@prettier/plugin-pug": "*",
+                "@shopify/prettier-plugin-liquid": "*",
+                "@shufo/prettier-plugin-blade": "*",
+                "@trivago/prettier-plugin-sort-imports": "*",
+                "prettier": ">=2.2.0",
+                "prettier-plugin-astro": "*",
+                "prettier-plugin-css-order": "*",
+                "prettier-plugin-import-sort": "*",
+                "prettier-plugin-jsdoc": "*",
+                "prettier-plugin-marko": "*",
+                "prettier-plugin-organize-attributes": "*",
+                "prettier-plugin-organize-imports": "*",
+                "prettier-plugin-style-order": "*",
+                "prettier-plugin-svelte": "*",
+                "prettier-plugin-twig-melody": "*"
+            },
+            "peerDependenciesMeta": {
+                "@ianvs/prettier-plugin-sort-imports": {
+                    "optional": true
+                },
+                "@prettier/plugin-pug": {
+                    "optional": true
+                },
+                "@shopify/prettier-plugin-liquid": {
+                    "optional": true
+                },
+                "@shufo/prettier-plugin-blade": {
+                    "optional": true
+                },
+                "@trivago/prettier-plugin-sort-imports": {
+                    "optional": true
+                },
+                "prettier-plugin-astro": {
+                    "optional": true
+                },
+                "prettier-plugin-css-order": {
+                    "optional": true
+                },
+                "prettier-plugin-import-sort": {
+                    "optional": true
+                },
+                "prettier-plugin-jsdoc": {
+                    "optional": true
+                },
+                "prettier-plugin-marko": {
+                    "optional": true
+                },
+                "prettier-plugin-organize-attributes": {
+                    "optional": true
+                },
+                "prettier-plugin-organize-imports": {
+                    "optional": true
+                },
+                "prettier-plugin-style-order": {
+                    "optional": true
+                },
+                "prettier-plugin-svelte": {
+                    "optional": true
+                },
+                "prettier-plugin-twig-melody": {
+                    "optional": true
+                }
             }
         },
         "node_modules/pretty-bytes": {
@@ -15992,15 +16698,6 @@
                 "react-dom": ">= 16.x"
             }
         },
-        "node_modules/react-ga": {
-            "version": "2.7.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "peerDependencies": {
-                "prop-types": "^15.6.0",
-                "react": "^15.6.2 || ^16.0"
-            }
-        },
         "node_modules/react-is": {
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -16197,6 +16894,15 @@
             "peerDependencies": {
                 "react": ">=16.6.0",
                 "react-dom": ">=16.6.0"
+            }
+        },
+        "node_modules/read-cache": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+            "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+            "dev": true,
+            "dependencies": {
+                "pify": "^2.3.0"
             }
         },
         "node_modules/read-pkg": {
@@ -18035,6 +18741,57 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
+        "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/string.prototype.matchall": {
             "version": "4.0.8",
             "dev": true,
@@ -18119,6 +18876,28 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/strip-bom": {
             "version": "3.0.0",
             "dev": true,
@@ -18155,6 +18934,57 @@
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/sucrase": {
+            "version": "3.34.0",
+            "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.34.0.tgz",
+            "integrity": "sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.2",
+                "commander": "^4.0.0",
+                "glob": "7.1.6",
+                "lines-and-columns": "^1.1.6",
+                "mz": "^2.7.0",
+                "pirates": "^4.0.1",
+                "ts-interface-checker": "^0.1.9"
+            },
+            "bin": {
+                "sucrase": "bin/sucrase",
+                "sucrase-node": "bin/sucrase-node"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/sucrase/node_modules/commander": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+            "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/sucrase/node_modules/glob": {
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/sumchecker": {
@@ -18307,6 +19137,62 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/tailwindcss": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.2.tgz",
+            "integrity": "sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==",
+            "dev": true,
+            "dependencies": {
+                "@alloc/quick-lru": "^5.2.0",
+                "arg": "^5.0.2",
+                "chokidar": "^3.5.3",
+                "didyoumean": "^1.2.2",
+                "dlv": "^1.1.3",
+                "fast-glob": "^3.2.12",
+                "glob-parent": "^6.0.2",
+                "is-glob": "^4.0.3",
+                "jiti": "^1.18.2",
+                "lilconfig": "^2.1.0",
+                "micromatch": "^4.0.5",
+                "normalize-path": "^3.0.0",
+                "object-hash": "^3.0.0",
+                "picocolors": "^1.0.0",
+                "postcss": "^8.4.23",
+                "postcss-import": "^15.1.0",
+                "postcss-js": "^4.0.1",
+                "postcss-load-config": "^4.0.1",
+                "postcss-nested": "^6.0.1",
+                "postcss-selector-parser": "^6.0.11",
+                "postcss-value-parser": "^4.2.0",
+                "resolve": "^1.22.2",
+                "sucrase": "^3.32.0"
+            },
+            "bin": {
+                "tailwind": "lib/cli.js",
+                "tailwindcss": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tailwindcss/node_modules/arg": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+            "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+            "dev": true
+        },
+        "node_modules/tailwindcss/node_modules/glob-parent": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+            "dev": true,
+            "dependencies": {
+                "is-glob": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
             }
         },
         "node_modules/tapable": {
@@ -18462,6 +19348,27 @@
             "version": "0.2.0",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/thenify": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+            "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+            "dev": true,
+            "dependencies": {
+                "any-promise": "^1.0.0"
+            }
+        },
+        "node_modules/thenify-all": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+            "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+            "dev": true,
+            "dependencies": {
+                "thenify": ">= 3.1.0 < 4"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
         },
         "node_modules/through": {
             "version": "2.3.8",
@@ -18634,6 +19541,12 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
+        },
+        "node_modules/ts-interface-checker": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+            "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+            "dev": true
         },
         "node_modules/ts-node": {
             "version": "10.9.1",
@@ -19073,8 +19986,9 @@
         },
         "node_modules/util": {
             "version": "0.12.5",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+            "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.3",
                 "is-arguments": "^1.0.4",
@@ -19504,6 +20418,107 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/wrapped": {
             "version": "1.0.1",
             "dev": true,
@@ -19611,6 +20626,15 @@
             "version": "3.1.1",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/yaml": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+            "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 14"
+            }
         },
         "node_modules/yargs": {
             "version": "3.32.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "check-disk-space": "^2.1.0",
                 "jest-fetch-mock": "^3.0.3",
                 "mcc-mnc-list": "^1.1.11",
-                "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v76",
+                "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v79",
                 "pretty-bytes": "^5.6.0",
                 "react-chartjs-2": "^5.2.0",
                 "redux-mock-store": "^1.5.4",
@@ -15489,8 +15489,8 @@
             }
         },
         "node_modules/pc-nrfconnect-shared": {
-            "version": "76.0.0",
-            "resolved": "git+ssh://git@github.com/NordicSemiconductor/pc-nrfconnect-shared.git#00749960bf38fb6ca3f8d21f51888e1ee83565e6",
+            "version": "79.0.0",
+            "resolved": "git+ssh://git@github.com/NordicSemiconductor/pc-nrfconnect-shared.git#a3e8c18863af1df8a8b5dfdfd164f633d5ed2f98",
             "dev": true,
             "hasInstallScript": true,
             "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "check-disk-space": "^2.1.0",
         "jest-fetch-mock": "^3.0.3",
         "mcc-mnc-list": "^1.1.11",
-        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v62",
+        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v76",
         "pretty-bytes": "^5.6.0",
         "react-chartjs-2": "^5.2.0",
         "redux-mock-store": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "check-disk-space": "^2.1.0",
         "jest-fetch-mock": "^3.0.3",
         "mcc-mnc-list": "^1.1.11",
-        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v76",
+        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v79",
         "pretty-bytes": "^5.6.0",
         "react-chartjs-2": "^5.2.0",
         "redux-mock-store": "^1.5.4",

--- a/src/features/certificateManager/CertificateManager.tsx
+++ b/src/features/certificateManager/CertificateManager.tsx
@@ -231,7 +231,7 @@ export default ({ active }: { active: boolean }) => {
     return (
         <div className={`${className} ${active ? 'hidden' : ''}`}>
             <Alert variant="info">
-                <span className="float-left h-100 mdi mdi-information mdi-36px pr-3" />
+                <span className="h-100 mdi mdi-information mdi-36px float-left pr-3" />
                 <div style={{ lineHeight: '1.5rem', userSelect: 'text' }}>
                     The modem must be in <strong>offline</strong> state (
                     <code>AT+CFUN=4</code>) for updating certificates.
@@ -249,7 +249,7 @@ export default ({ active }: { active: boolean }) => {
                     tag.
                 </div>
             </Alert>
-            <Form className="mt-4 mb-4 pr-4">
+            <Form className="mb-4 mt-4 pr-4">
                 <Row>
                     <Col xs={8}>
                         {FormGroupWithCheckbox({

--- a/src/features/dashboard/Chart/ChartTop.tsx
+++ b/src/features/dashboard/Chart/ChartTop.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Button, Toggle } from 'pc-nrfconnect-shared';
+import { Toggle } from 'pc-nrfconnect-shared';
 
 import { getLive, setLive, setShowOptionsDialog } from './chartSlice';
 
@@ -21,13 +21,13 @@ export default ({ marginLeft }: { marginLeft: number }) => {
             }}
         >
             <p>Packet Event Viewer</p>
-            <div className="d-flex flex-row justify-content-end">
-                <Button
-                    variant="custom"
+            <div className="d-flex justify-content-end flex-row">
+                <button
+                    type="button"
                     onClick={() => dispatch(setShowOptionsDialog(true))}
                 >
                     <span className="mdi mdi-cog" /> <p>SETTINGS</p>
-                </Button>
+                </button>
                 <Toggle
                     label="LIVE"
                     isToggled={isLive}

--- a/src/features/programSample/ProgramSampleModal.tsx
+++ b/src/features/programSample/ProgramSampleModal.tsx
@@ -154,7 +154,7 @@ const SelectSample = ({
                     {samples.map(sample => (
                         <div
                             key={sample.title}
-                            className="card-in-card p-3 d-flex flex-column"
+                            className="card-in-card d-flex flex-column p-3"
                         >
                             <strong className="d-block">{sample.title}</strong>
                             <p className="flex-grow-1 py-2">
@@ -464,7 +464,7 @@ const ProgramModem = ({
                     {modemFirmwares.map(mfw => (
                         <div
                             key={mfw.title}
-                            className="card-in-card p-3 d-flex flex-column"
+                            className="card-in-card d-flex flex-column p-3"
                         >
                             <strong className="d-block">{mfw.title}</strong>
                             <p className="flex-grow-1 py-2">

--- a/src/features/terminal/index.tsx
+++ b/src/features/terminal/index.tsx
@@ -6,11 +6,11 @@
 
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { ipcRenderer } from 'electron';
 import {
+    apps,
     Button,
     Device,
-    openAppWindow,
+    openWindow,
     selectedDevice,
     usageData,
 } from 'pc-nrfconnect-shared';
@@ -56,7 +56,7 @@ export const OpenSerialTerminal = () => {
 
 const openSerialTerminal = (device: Device, serialPortPath: string) => {
     usageData.sendUsageData(EventAction.OPEN_SERIAL_TERMINAL);
-    openAppWindow(
+    openWindow.openApp(
         { name: 'pc-nrfconnect-serial-terminal', source: 'official' },
         {
             device: {
@@ -68,20 +68,12 @@ const openSerialTerminal = (device: Device, serialPortPath: string) => {
 };
 
 const detectInstalledApp = async () => {
-    const downloadableApps = (await ipcRenderer.invoke(
-        'apps:get-downloadable-apps'
-    )) as {
-        apps: {
-            name: string;
-            source: string;
-            installed?: object;
-        }[];
-    };
+    const downloadableApps = await apps.getDownloadableApps();
 
     return downloadableApps.apps.some(
         app =>
             app.source === 'official' &&
             app.name === 'pc-nrfconnect-serial-terminal' &&
-            app.installed !== undefined
+            apps.isInstalled(app)
     );
 };

--- a/src/features/terminal/index.tsx
+++ b/src/features/terminal/index.tsx
@@ -37,7 +37,7 @@ export const OpenSerialTerminal = () => {
 
     return (
         <Button
-            className="w-100 mt-2 position-relative"
+            className="w-100 position-relative mt-2"
             onClick={() =>
                 openSerialTerminal(device, selectedUartSerialPort.path)
             }


### PR DESCRIPTION
Use the new calls from shared (with the correct signatures) instead of using `ipcRenderer` directly.

I am unsure whether something else needs to be changed here because of the update of shared from v62 to v79 but I think I fixed what was needed (Updating some CSS classnames order and replacing the usage of the custom variant of `Button`).