### PR TITLE
Downloading or copying modem firmware failed

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,8 @@
 
 -   In some cases, the **Refresh dashboard** button was visible after
     deselecting device.
+-   Was not able to copy modem firmware zip if target directory did not exist,
+    meaning that programming modem firmware failed.
 
 ### Changed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,8 +13,7 @@
 
 -   In some cases, the **Refresh dashboard** button was visible after
     deselecting device.
--   Was not able to copy modem firmware zip if target directory did not exist,
-    meaning that programming modem firmware failed.
+-   Programming modem firmware failed if target directory did not exist.
 
 ### Changed
 

--- a/src/features/programSample/samples.ts
+++ b/src/features/programSample/samples.ts
@@ -9,7 +9,7 @@ import {
     getAppDir,
     logger,
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
-import { existsSync } from 'fs';
+import { existsSync, mkdirSync } from 'fs';
 import { copyFile, mkdir, readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 
@@ -63,8 +63,12 @@ export const downloadSampleIndex = () =>
         cache: 'no-cache',
     }).then<Samples>(result => result.json());
 
-export const downloadModemFirmware = (modemFirmware: ModemFirmware) =>
+export const downloadModemFirmware = (modemFirmware: ModemFirmware) => {
+    if (!existsSync(DOWNLOAD_FOLDER)) {
+        mkdirSync(DOWNLOAD_FOLDER);
+    }
     downloadFile(modemFirmware.file);
+};
 
 export const downloadSample = async (sample: Sample) => {
     if (!existsSync(DOWNLOAD_FOLDER)) {


### PR DESCRIPTION
Need to make sure that the target folder exists before copying into the folder.