### PR TITLE
fix: logging device as [object Object]

### DIFF
--- a/src/features/programSample/programSample.ts
+++ b/src/features/programSample/programSample.ts
@@ -39,7 +39,7 @@ export const getNrfDeviceVersion = (
 
     logger.error(
         'Attempted to retrieve trace databases for an unrecognized device',
-        device
+        JSON.stringify(device)
     );
     return undefined as never;
 };


### PR DESCRIPTION
In this case it could be useful to see the full device information, as it could potentially help us identify what is wrong with the device. Hence, log the whole device, but make sure to JSON.stringify it.