### PR TITLE
Bump font-size to 12px and fix contrast issues

### DIFF
--- a/src/features/dashboard/Chart/Chart.tsx
+++ b/src/features/dashboard/Chart/Chart.tsx
@@ -115,10 +115,10 @@ export default () => {
             scales: {
                 y: {
                     ticks: {
-                        padding: 10,
-                        color: sharedColors.gray700,
+                        padding: 12,
+                        color: sharedColors.gray900,
                         font: {
-                            size: 10,
+                            size: 12,
                             lineHeight: 1,
                         },
                         backdropPadding: 0,
@@ -144,8 +144,8 @@ export default () => {
                     border: {
                         display: false,
                     },
-                    suggestedMin: -0.5,
-                    suggestedMax: traceEventFilter.length - 0.5,
+                    min: -0.5,
+                    max: traceEventFilter.length - 0.5,
                 },
                 x: {
                     type: 'linear',
@@ -193,21 +193,10 @@ export default () => {
         [dispatch, traceEventFilter]
     );
 
-    const sectionHeight = 13;
-    const sectionSeperatorHeight = 1;
-    const chartHeight =
-        sectionHeight * traceEventFilter.length +
-        sectionSeperatorHeight * (traceEventFilter.length - 1);
-
     return (
         <>
             <ChartTop marginLeft={chart.current?.chartArea.left ?? 0} />
-            <div
-                className="chart-data"
-                style={{
-                    height: `${chartHeight}px`,
-                }}
-            >
+            <div className="chart-data">
                 <Scatter
                     ref={chart}
                     options={options}

--- a/src/features/dashboard/Chart/chart.scss
+++ b/src/features/dashboard/Chart/chart.scss
@@ -26,31 +26,31 @@
             margin-right: 8px;
             border: 0;
             background: $gray-200;
-            font-size: 10px;
+            font-size: 12px;
             .mdi {
                 line-height: 1;
                 margin-top: 0;
                 margin-bottom: 0;
                 font-size: 12px;
                 margin-right: 4px;
-                color: $gray-700;
+                color: $gray-900;
             }
         }
 
         p {
-            font-size: 10px;
+            font-size: 12px;
             margin: 0;
-            color: $gray-700;
+            color: $gray-900;
         }
 
         .toggle {
             label {
                 span {
-                    color: $gray-700;
+                    color: $gray-900;
                 }
             }
             .toggle-label {
-                font-size: 10px;
+                font-size: 12px;
             }
             .toggle-handle {
                 height: 8px;

--- a/src/features/dashboard/Chart/timeSpanDeltaLine.scss
+++ b/src/features/dashboard/Chart/timeSpanDeltaLine.scss
@@ -20,10 +20,10 @@
     // 8 for the border left/right and 8 for above that
     margin-top: 16px;
 
-    color: $gray-700;
+    color: $gray-900;
 
     text-align: center;
-    border-top: 1px solid $gray-700;
+    border-top: 1px solid $gray-900;
 
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
Remove fixed height of the chart, as it should responsively fit with the content of the chart. Rather set min/max on the y-axis, and make sure the fonts and colors are consistent.

This changes the Packet Event Viewer signficantly, with regards to how it looks. May have made the chart iself a bit big, but at least then you see it 🤭

Result:
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor/assets/34618612/47429d18-64ce-46f3-b5cd-d6d982620302)
