### PR TITLE
fix: make log messages more intuitive

### DIFF
--- a/src/utils/monitorLibLogging.ts
+++ b/src/utils/monitorLibLogging.ts
@@ -9,20 +9,24 @@ import { logger } from '@nordicsemiconductor/pc-nrfconnect-shared';
 import { getIsLoggingVerbose } from '@nordicsemiconductor/pc-nrfconnect-shared/src/utils/persistentStore';
 
 export function enableNrfmlLogging() {
-    setNrfmlLogLevel(getIsLoggingVerbose());
-
     nrfml.startLogEvents(
         () => logger.debug('Logging from nrf-monitor-lib has been disabled.'),
         logEvent => {
             logger.debug(logEvent.message);
         }
     );
-    logger.info(`Enabled logging from nrf-monitor-lib.`);
+    setNrfmlLogLevel(getIsLoggingVerbose());
 }
 
 export function setNrfmlLogLevel(verbose: boolean) {
     const logLevel = verbose ? nrfml.NRFML_LOG_TRACE : nrfml.NRFML_LOG_OFF;
     nrfml.setLogLevel(logLevel);
 
-    logger.info(`Changed log level from nrf-monitor-lib to: "${logLevel}"`);
+    if (logLevel > 0) {
+        logger.info(
+            `nrf-monitor-lib logging with is enabled with log level: ${logLevel}.`
+        );
+    } else {
+        logger.info('nrf-monitor-lib logging is disabled.');
+    }
 }


### PR DESCRIPTION
When opening Cellular Monitor, and reading that logging is enabled with log level "0", makes it sound like the user should expect to get logging from nrf-monitor-lib.

Make it more understandable when the logging is off, and when it is on, so that when the user actually turns it on, then the user can be confident that the logging is on.