### PR TITLE
fix: accessed wrong property to determine device

### DIFF
--- a/src/features/programSample/programSample.ts
+++ b/src/features/programSample/programSample.ts
@@ -44,8 +44,15 @@ export const getNrfDeviceVersion = (
     return undefined as never;
 };
 
-export const isThingy91 = (device?: Device) =>
-    device?.devkit?.boardVersion === '9100';
+export const isThingy91 = (device?: Device) => {
+    const serialPorts = device?.serialPorts;
+
+    if (serialPorts == null) {
+        return false;
+    }
+
+    return serialPorts.some(port => port.productId === '9100');
+};
 
 export const is9160DK = (device?: Device) =>
     device?.devkit?.boardVersion === 'PCA10090';


### PR DESCRIPTION
Thingy91 is not a devkit, and will never have the devkit property. It does however, have the productId property on its serialPorts.