### PR TITLE
doc: replace infocenter and dev.nordicsemi links

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## 2.2.1 - UNRELEASED
+
+### Changed
+
+-   Updated documentation links to point to the TechDocs platform.
+
 ## 2.2.0 - 2024-03-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 [![Build Status](https://dev.azure.com/NordicSemiconductor/Wayland/_apis/build/status/pc-nrfconnect-cellularmonitor?branchName=main)](https://dev.azure.com/NordicSemiconductor/Wayland/_build/latest?definitionId=153&branchName=main)
 [![License](https://img.shields.io/badge/license-Modified%20BSD%20License-blue.svg)](LICENSE)
 
-_nRF Connect Cellular Monitor_ is a tool that enables you to capture and analyze
+nRF Connect Cellular Monitor is a tool that enables you to capture and analyze
 modem traces.
 
 ## Installation
 
-See the
-[InfoCenter](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fstruct_nrftools%2Fstruct%2Fnrftools_nrfconnect.html)
-pages for information on how to install the application.
+Read the
+[nRF Connect Cellular Monitor](https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/index.html)
+official documentation.
 
 ## Development
 

--- a/doc/docs/overview.md
+++ b/doc/docs/overview.md
@@ -119,10 +119,6 @@ See [Viewing a Modem trace in Cellular Monitor](./viewing.md) for more informati
 
 See [Managing modem credentials](./managing_credentials.md).
 
-## Feedback tab
-
-The Feedback tab lets you send feedback about nRF Connect Cellular Monitor application to the application development team.
-
 ## Log
 
 The Log panel allows you to view the most important log events, tagged with a timestamp. Each time you open the app, a new session log file is created. You can find the Log panel and its controls, below the main application Window.
@@ -134,4 +130,4 @@ The Log panel allows you to view the most important log events, tagged with a ti
 
 ## About tab
 
-You can view application information, restore defaults, access source code, and documentation. You also can find information on the selected device, access support tools, and enable verbose logging.
+You can view application information, restore defaults, access source code and documentation. You also can find information on the selected device, access support tools, send feedback, and enable verbose logging.

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,9 +42,9 @@
             }
         },
         "node_modules/@adobe/css-tools": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
-            "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
+            "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==",
             "dev": true
         },
         "node_modules/@alloc/quick-lru": {
@@ -174,13 +174,13 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.22.13",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-            "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+            "version": "7.24.2",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+            "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.22.13",
-                "chalk": "^2.4.2"
+                "@babel/highlight": "^7.24.2",
+                "picocolors": "^1.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -235,14 +235,14 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.15.tgz",
-            "integrity": "sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.1.tgz",
+            "integrity": "sha512-DfCRfZsBcrPEHUfuBMgbJ1Ut01Y/itOs+hY2nFLgqsqXd52/iSiVq5TITtUasIUgm+IIKdY2/1I7auiQOEeC9A==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.15",
-                "@jridgewell/gen-mapping": "^0.3.2",
-                "@jridgewell/trace-mapping": "^0.3.17",
+                "@babel/types": "^7.24.0",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
             },
             "engines": {
@@ -284,13 +284,13 @@
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-            "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -373,9 +373,9 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+            "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -414,23 +414,24 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-            "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+            "version": "7.24.2",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+            "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.22.20",
                 "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0"
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.22.16",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
-            "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.1.tgz",
+            "integrity": "sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -643,20 +644,20 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.20.tgz",
-            "integrity": "sha512-eU260mPZbU7mZ0N+X10pxXhQFMGTeLb9eFS0mxehS8HZp9o1uSnFeWQuG1UPrlxgA7QoUzFhOnilHDp0AXCyHw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.1.tgz",
+            "integrity": "sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.22.13",
-                "@babel/generator": "^7.22.15",
+                "@babel/code-frame": "^7.24.1",
+                "@babel/generator": "^7.24.1",
                 "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-function-name": "^7.22.5",
+                "@babel/helper-function-name": "^7.23.0",
                 "@babel/helper-hoist-variables": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.22.16",
-                "@babel/types": "^7.22.19",
-                "debug": "^4.1.0",
+                "@babel/parser": "^7.24.1",
+                "@babel/types": "^7.24.0",
+                "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
             "engines": {
@@ -664,13 +665,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.22.19",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.19.tgz",
-            "integrity": "sha512-P7LAw/LbojPzkgp5oznjE6tQEIWbp4PkkfrZDINTro9zgBRtI324/EYsiSI7lhPbpIQ+DCeR2NNmMWANGGfZsg==",
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
+            "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.19",
+                "@babel/helper-string-parser": "^7.23.4",
+                "@babel/helper-validator-identifier": "^7.22.20",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -2607,14 +2608,14 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
@@ -2630,9 +2631,9 @@
             }
         },
         "node_modules/@jridgewell/set-array": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "dev": true,
             "engines": {
                 "node": ">=6.0.0"
@@ -2645,9 +2646,9 @@
             "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-            "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-cellularmonitor",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "description": "Capture and analyze modem traces",
     "displayName": "Cellular Monitor",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor",

--- a/resources/firmware/index.json
+++ b/resources/firmware/index.json
@@ -1,9 +1,9 @@
 {
     "thingy91": [
         {
-            "title": "Asset Tracker V2",
+            "title": "Asset Tracker v2",
             "description": "This is the default application on your Thingy91.",
-            "documentation": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/README.html",
+            "documentation": "https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/applications/asset_tracker_v2/README.html",
             "fw": [
                 {
                     "type": "Application",
@@ -14,7 +14,7 @@
         {
             "title": "Serial LTE Modem",
             "description": "Use this application if you want to evaluate the modem using an external MCU.",
-            "documentation": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/serial_lte_modem/README.html",
+            "documentation": "https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/applications/serial_lte_modem/README.html",
             "fw": [
                 {
                     "type": "Application",
@@ -25,7 +25,7 @@
         {
             "title": "Modem Shell",
             "description": "The Modem Shell (MoSh) sample application enables you to test various device connectivity features, including data throughput.",
-            "documentation": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/nrf9160/modem_shell/README.html",
+            "documentation": "https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/cellular/modem_shell/README.html",
             "fw": [
                 {
                     "type": "Application",
@@ -36,9 +36,9 @@
     ],
     "dk91": [
         {
-            "title": "Asset Tracker V2",
+            "title": "Asset Tracker v2",
             "description": "This is the default application on your development kit.",
-            "documentation": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/README.html",
+            "documentation": "https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/applications/asset_tracker_v2/README.html",
             "fw": [
                 {
                     "type": "Modem",
@@ -51,9 +51,9 @@
             ]
         },
         {
-            "title": "Serial LTE ",
+            "title": "Serial LTE Modem",
             "description": "Use this application if you want to evaluate the modem using an external MCU.",
-            "documentation": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/serial_lte_modem/README.html",
+            "documentation": "https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/applications/serial_lte_modem/README.html",
             "fw": [
                 {
                     "type": "Modem",
@@ -68,7 +68,7 @@
         {
             "title": "Modem Shell",
             "description": "The Modem Shell (MoSh) sample application enables you to test various device connectivity features, including data throughput.",
-            "documentation": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/nrf9160/modem_shell/README.html",
+            "documentation": "https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/cellular/modem_shell/README.html",
             "fw": [
                 {
                     "type": "Modem",

--- a/src/app/DocumentationSection.tsx
+++ b/src/app/DocumentationSection.tsx
@@ -12,17 +12,17 @@ import StartupDialog from '../features/startup/startupDialog';
 const DocumentationSections = [
     <DocumentationSection
         key="infocenter"
-        linkLabel="Go to Infocenter"
-        link="https://infocenter.nordicsemi.com/topic/ug_cellular_monitor/UG/cellular_monitor/intro.html"
+        linkLabel="Go to TechDocs"
+        link="https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/index.html"
     >
-        Visit our Infocenter for more documentation about using the app.
+        Visit our Technical Documentation for more documentation about using the app.
     </DocumentationSection>,
     <DocumentationSection
         key="credentialManager"
         linkLabel="Certificate Manager"
-        link="https://infocenter.nordicsemi.com/topic/ug_link_monitor/UG/link_monitor/lm_certificate_manager.html"
+        link="https://docs.nordicsemi.com/bundle/nrf-connect-linkmonitor/page/lm_certificate_manager.html"
     >
-        Visit our Infocenter for more documentation about managing credentials.
+        Visit our Technical Documentation for more documentation about managing credentials.
     </DocumentationSection>,
     <StartupDialog key="default-startup-dialog" />,
 ];

--- a/src/app/DocumentationSection.tsx
+++ b/src/app/DocumentationSection.tsx
@@ -15,14 +15,16 @@ const DocumentationSections = [
         linkLabel="Go to TechDocs"
         link="https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/index.html"
     >
-        Visit our Technical Documentation for more documentation about using the app.
+        Visit our Technical Documentation for more documentation about using the
+        app.
     </DocumentationSection>,
     <DocumentationSection
         key="credentialManager"
         linkLabel="Certificate Manager"
         link="https://docs.nordicsemi.com/bundle/nrf-connect-linkmonitor/page/lm_certificate_manager.html"
     >
-        Visit our Technical Documentation for more documentation about managing credentials.
+        Visit our Technical Documentation for more documentation about managing
+        credentials.
     </DocumentationSection>,
     <StartupDialog key="default-startup-dialog" />,
 ];

--- a/src/features/tracingEvents/at/commandProcessors/TXPowerReduction.ts
+++ b/src/features/tracingEvents/at/commandProcessors/TXPowerReduction.ts
@@ -31,7 +31,7 @@ let requestedReduction: ViewModel | undefined;
 export const processor: Processor<'%XEMPR'> = {
     command: '%XEMPR',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/xempr.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/mob_termination_ctrl_status/xempr.html',
     initialState: () => ({}),
     onRequest: (packet, state) => {
         if (

--- a/src/features/tracingEvents/at/commandProcessors/connectivityStatistics.ts
+++ b/src/features/tracingEvents/at/commandProcessors/connectivityStatistics.ts
@@ -13,7 +13,7 @@ let setValue: boolean;
 export const processor: Processor<'%XCONNSTAT'> = {
     command: '%XCONNSTAT',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/xconnstat.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/mob_termination_ctrl_status/xconnstat.html',
     initialState: () => ({}),
     onRequest: (packet, state) => {
         if (

--- a/src/features/tracingEvents/at/commandProcessors/currentBand.ts
+++ b/src/features/tracingEvents/at/commandProcessors/currentBand.ts
@@ -12,7 +12,7 @@ export const processor: Processor<'%XCBAND'> = {
     command: '%XCBAND',
     initialState: () => ({}),
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/xcband.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/mob_termination_ctrl_status/xcband.html',
     onResponse: (packet, state, requestType) => {
         if (packet.status === 'OK' && packet.payload) {
             if (requestType === RequestType.TEST) {

--- a/src/features/tracingEvents/at/commandProcessors/dataProfile.ts
+++ b/src/features/tracingEvents/at/commandProcessors/dataProfile.ts
@@ -23,7 +23,7 @@ let requestedDataProfile: PowerLevel | undefined;
 export const processor: Processor<'%XDATAPRFL'> = {
     command: '%XDATAPRFL',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/xdataprfl.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/mob_termination_ctrl_status/xdataprfl.html',
     initialState: () => ({}),
     onRequest: (packet, state) => {
         if (packet.payload) {

--- a/src/features/tracingEvents/at/commandProcessors/deviceActivityStatus.ts
+++ b/src/features/tracingEvents/at/commandProcessors/deviceActivityStatus.ts
@@ -20,7 +20,7 @@ export type ActivityStatus = keyof typeof activityStatus;
 export const processor: Processor<'+CPAS'> = {
     command: '+CPAS',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/cpas.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/mob_termination_ctrl_status/cpas.html',
     initialState: () => ({}),
     onResponse(packet, state) {
         if (packet.status === 'OK') {

--- a/src/features/tracingEvents/at/commandProcessors/eDrxDynamicParameters.ts
+++ b/src/features/tracingEvents/at/commandProcessors/eDrxDynamicParameters.ts
@@ -10,7 +10,7 @@ import { parseEdrxPayloadLines } from './eDrxSetting';
 export const processor: Processor<'+CEDRXRDP'> = {
     command: '+CEDRXRDP',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/nw_service/cedrxrdp.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/nw_service/cedrxrdp.html',
     initialState: () => ({}),
     onResponse: (packet, state) => {
         if (packet.status === 'OK' && packet.payload) {

--- a/src/features/tracingEvents/at/commandProcessors/eDrxSetting.ts
+++ b/src/features/tracingEvents/at/commandProcessors/eDrxSetting.ts
@@ -19,7 +19,7 @@ const setPayload: SetPayload = {};
 export const processor: Processor<'+CEDRXS'> = {
     command: '+CEDRXS',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/nw_service/cedrxs.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/nw_service/cedrxs.html',
     initialState: () => ({}),
     onRequest: (packet, state) => {
         if (

--- a/src/features/tracingEvents/at/commandProcessors/evaluatingConnectionParameters.ts
+++ b/src/features/tracingEvents/at/commandProcessors/evaluatingConnectionParameters.ts
@@ -18,7 +18,7 @@ import { getParametersFromResponse } from '../utils';
 export const processor: Processor<'%CONEVAL'> = {
     command: '%CONEVAL',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/coneval.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/mob_termination_ctrl_status/coneval.html',
     initialState: () => ({}),
     onResponse: (packet, state) => {
         if (packet.status === 'OK') {

--- a/src/features/tracingEvents/at/commandProcessors/extendedSignalQuality.ts
+++ b/src/features/tracingEvents/at/commandProcessors/extendedSignalQuality.ts
@@ -11,7 +11,7 @@ import { getNumberArray } from '../utils';
 export const processor: Processor<'+CESQ'> = {
     command: '+CESQ',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/cesq.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/mob_termination_ctrl_status/cesq.html',
     initialState: () => ({
         signalQuality: {},
     }),

--- a/src/features/tracingEvents/at/commandProcessors/functionMode.ts
+++ b/src/features/tracingEvents/at/commandProcessors/functionMode.ts
@@ -30,7 +30,7 @@ let requestedMode: FunctionalMode;
 export const processor: Processor<'+CFUN'> = {
     command: '+CFUN',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/cfun.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/mob_termination_ctrl_status/cfun.html',
     initialState: () => ({}),
     onRequest: (packet, state) => {
         if (

--- a/src/features/tracingEvents/at/commandProcessors/hardwareVersion.ts
+++ b/src/features/tracingEvents/at/commandProcessors/hardwareVersion.ts
@@ -10,7 +10,7 @@ import { parseStringValue } from '../utils';
 export const processor: Processor<'%HWVERSION'> = {
     command: '%HWVERSION',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/general/hwver.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/general/hwver.html',
     initialState: () => ({}),
     onResponse: (packet, state) => {
         if (packet.status === 'OK' && packet.payload) {

--- a/src/features/tracingEvents/at/commandProcessors/iccid.ts
+++ b/src/features/tracingEvents/at/commandProcessors/iccid.ts
@@ -10,7 +10,7 @@ import { parseStringValue } from '../utils';
 export const processor: Processor<'%XICCID'> = {
     command: '%XICCID',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/access_uicc/xiccid.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/access_uicc/xiccid.html',
     initialState: () => ({}),
     onResponse: (packet, state) => {
         if (packet.status === 'OK') {

--- a/src/features/tracingEvents/at/commandProcessors/internationalMobileSubscriberIdentity.ts
+++ b/src/features/tracingEvents/at/commandProcessors/internationalMobileSubscriberIdentity.ts
@@ -9,7 +9,7 @@ import type { Processor } from '..';
 export const processor: Processor<'+CIMI'> = {
     command: '+CIMI',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/access_uicc/cimi.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/access_uicc/cimi.html',
     initialState: () => ({}),
     onResponse: (packet, state) => {
         if (packet.status === 'OK') {

--- a/src/features/tracingEvents/at/commandProcessors/manufacturerIdentification.ts
+++ b/src/features/tracingEvents/at/commandProcessors/manufacturerIdentification.ts
@@ -10,7 +10,7 @@ import type { Processor } from '..';
 export const processor: Processor<'+CGMI'> = {
     command: '+CGMI',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/general/cgmi.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/general/cgmi.html',
     initialState: () => ({}),
     onResponse: (packet, state) => {
         if (packet.status === 'OK') {

--- a/src/features/tracingEvents/at/commandProcessors/modeOfOperation.ts
+++ b/src/features/tracingEvents/at/commandProcessors/modeOfOperation.ts
@@ -13,7 +13,7 @@ let requestedModeOfOperation = -1;
 export const processor: Processor<'+CEMODE'> = {
     command: '+CEMODE',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/cemode.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/mob_termination_ctrl_status/cemode.html',
     initialState: () => ({}),
     onRequest: (packet, state) => {
         if (

--- a/src/features/tracingEvents/at/commandProcessors/modemDomainEventNotification.ts
+++ b/src/features/tracingEvents/at/commandProcessors/modemDomainEventNotification.ts
@@ -21,7 +21,7 @@ let setNotification: 0 | 1;
 export const processor: Processor<'%MDMEV'> = {
     command: '%MDMEV',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/mdmev.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/mob_termination_ctrl_status/mdmev.html',
     initialState: () => ({}),
     onRequest: (packet, state) => {
         if (

--- a/src/features/tracingEvents/at/commandProcessors/modemParameters.ts
+++ b/src/features/tracingEvents/at/commandProcessors/modemParameters.ts
@@ -19,7 +19,7 @@ import { getNumber, getParametersFromResponse } from '../utils';
 export const processor: Processor<'%XMONITOR'> = {
     command: '%XMONITOR',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/nw_service/xmonitor.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/nw_service/xmonitor.html',
     initialState: () => ({}),
     onResponse: (packet, state) => {
         if (packet.status === 'OK') {

--- a/src/features/tracingEvents/at/commandProcessors/modemTraceActivation.ts
+++ b/src/features/tracingEvents/at/commandProcessors/modemTraceActivation.ts
@@ -16,7 +16,7 @@ let setPayload: {
 export const processor: Processor<'%XMODEMTRACE'> = {
     command: '%XMODEMTRACE',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/xmodemtrace.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/mob_termination_ctrl_status/xmodemtrace.html',
     initialState: () => ({}),
     onRequest: (packet, state) => {
         if (packet.requestType === RequestType.SET_WITH_VALUE) {

--- a/src/features/tracingEvents/at/commandProcessors/modemUUID.ts
+++ b/src/features/tracingEvents/at/commandProcessors/modemUUID.ts
@@ -9,7 +9,7 @@ import type { Processor } from '..';
 export const processor: Processor<'%XMODEMUUID'> = {
     command: '%XMODEMUUID',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/general/modemuuid.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/general/modemuuid.html',
     initialState: () => ({}),
     onResponse: (packet, state) => {
         if (packet.status === 'OK') {

--- a/src/features/tracingEvents/at/commandProcessors/networkRegistrationStatusNotification.ts
+++ b/src/features/tracingEvents/at/commandProcessors/networkRegistrationStatusNotification.ts
@@ -24,7 +24,7 @@ let setPayload: NetworkStatusNotifications;
 export const processor: Processor<'+CEREG'> = {
     command: '+CEREG',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/nw_service/cereg.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/nw_service/cereg.html',
     initialState: () => ({}),
     onRequest: (packet, state) => {
         if (packet.requestType === RequestType.SET_WITH_VALUE) {

--- a/src/features/tracingEvents/at/commandProcessors/networkTimeNotification.ts
+++ b/src/features/tracingEvents/at/commandProcessors/networkTimeNotification.ts
@@ -13,7 +13,7 @@ let setValue: 0 | 1;
 export const processor: Processor<'%XTIME'> = {
     command: '%XTIME',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/nw_service/xtime.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/nw_service/xtime.html',
     initialState: () => ({}),
     onRequest: (packet, state) => {
         if (packet.requestType === RequestType.SET_WITH_VALUE) {

--- a/src/features/tracingEvents/at/commandProcessors/packetDomainEvents.ts
+++ b/src/features/tracingEvents/at/commandProcessors/packetDomainEvents.ts
@@ -31,7 +31,7 @@ const PacketDomainEvent = {
 export const processor: Processor<'+CGEV'> = {
     command: '+CGEV',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/packet_domain/cgev.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/packet_domain/cgev.html',
     initialState: () => ({}),
     onResponse: (packet, state) => {
         if (packet.payload) {

--- a/src/features/tracingEvents/at/commandProcessors/pdpContext.ts
+++ b/src/features/tracingEvents/at/commandProcessors/pdpContext.ts
@@ -12,7 +12,7 @@ import { getLines, getNumber, getParametersFromResponse } from '../utils';
 export const processor: Processor<'+CGDCONT'> = {
     command: '+CGDCONT',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/packet_domain/cgdcont.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/packet_domain/cgdcont.html',
     initialState: () => ({ accessPointNames: {} }),
     onResponse: (packet, state, requestType) => {
         if (packet.status === 'OK') {

--- a/src/features/tracingEvents/at/commandProcessors/periodicTAU.ts
+++ b/src/features/tracingEvents/at/commandProcessors/periodicTAU.ts
@@ -11,7 +11,7 @@ let parameters: number[];
 export const processor: Processor<'%XT3412'> = {
     command: '%XT3412',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/xt3412.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/mob_termination_ctrl_status/xt3412.html',
     initialState: () => ({ notifyPeriodicTAU: false }),
 
     onRequest: (packet, state) => {

--- a/src/features/tracingEvents/at/commandProcessors/pinCode.ts
+++ b/src/features/tracingEvents/at/commandProcessors/pinCode.ts
@@ -25,7 +25,7 @@ type PinCodeStatus = keyof typeof pinCodeStatus;
 export const processor: Processor<'+CPIN'> = {
     command: '+CPIN',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/security/cpin.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/security/cpin.html',
     initialState: () => ({ pinCodeStatus: 'Unknown' }),
     onResponse: (packet, state) => {
         if (packet.status === 'OK') {

--- a/src/features/tracingEvents/at/commandProcessors/pinRetries.ts
+++ b/src/features/tracingEvents/at/commandProcessors/pinRetries.ts
@@ -10,7 +10,7 @@ import { getStringNumberPair } from '../utils';
 export const processor: Processor<'+CPINR'> = {
     command: '+CPINR',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/security/cpinr.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/security/cpinr.html',
     initialState: () => ({ pinRetries: {} }),
     onResponse: (packet, state) => {
         if (packet.status === 'OK') {

--- a/src/features/tracingEvents/at/commandProcessors/powerSavingModeSettings.ts
+++ b/src/features/tracingEvents/at/commandProcessors/powerSavingModeSettings.ts
@@ -44,7 +44,7 @@ let storedPowerSavingMode: PowerSavingModeEntries;
 export const processor: Processor<'+CPSMS'> = {
     command: '+CPSMS',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/nw_service/cpsms.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/nw_service/cpsms.html',
     initialState: () => ({
         powerSavingMode: {},
     }),

--- a/src/features/tracingEvents/at/commandProcessors/productSerialNumberId.ts
+++ b/src/features/tracingEvents/at/commandProcessors/productSerialNumberId.ts
@@ -11,7 +11,7 @@ import { parseStringValue } from '../utils';
 export const processor: Processor<'+CGSN'> = {
     command: '+CGSN',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/general/cgsn.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/general/cgsn.html',
     initialState: () => ({}),
     onResponse: (packet, state, requestType) => {
         if (

--- a/src/features/tracingEvents/at/commandProcessors/publicLandMobileNetwork.ts
+++ b/src/features/tracingEvents/at/commandProcessors/publicLandMobileNetwork.ts
@@ -21,7 +21,7 @@ let setPayload: Omit<PayloadParameters, 'AcTState'>;
 export const processor: Processor<'+COPS'> = {
     command: '+COPS',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/nw_service/cops.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/nw_service/cops.html',
     initialState: () => ({}),
     onRequest: (packet, state) => {
         if (

--- a/src/features/tracingEvents/at/commandProcessors/revisionIdentification.ts
+++ b/src/features/tracingEvents/at/commandProcessors/revisionIdentification.ts
@@ -10,7 +10,7 @@ import { parseStringValue } from '../utils';
 export const processor: Processor<'+CGMR'> = {
     command: '+CGMR',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/general/cgmr.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/general/cgmr.html',
     initialState: () => ({}),
     onResponse: (packet, state) => {
         if (packet.status === 'OK' && packet.payload) {

--- a/src/features/tracingEvents/at/commandProcessors/signalQualityNotification.ts
+++ b/src/features/tracingEvents/at/commandProcessors/signalQualityNotification.ts
@@ -25,7 +25,7 @@ let tentativeState: Partial<ViewModel> | null = null;
 export const processor: Processor<'%CESQ'> = {
     command: '%CESQ',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/proc_cesq.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/mob_termination_ctrl_status/proc_cesq.html',
     initialState: () => ({
         notifySignalQuality: false,
         signalQuality: {},

--- a/src/features/tracingEvents/at/commandProcessors/signalingConnectionStatusNotification.ts
+++ b/src/features/tracingEvents/at/commandProcessors/signalingConnectionStatusNotification.ts
@@ -17,7 +17,7 @@ let setPayload: SignalingConnectionStatusNotifications;
 export const processor: Processor<'+CSCON'> = {
     command: '+CSCON',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/packet_domain/cscon.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/packet_domain/cscon.html',
     initialState: () => ({}),
 
     onRequest: (packet, state) => {

--- a/src/features/tracingEvents/at/commandProcessors/systemMode.ts
+++ b/src/features/tracingEvents/at/commandProcessors/systemMode.ts
@@ -18,7 +18,7 @@ let setPayload: {
 export const processor: Processor<'%XSYSTEMMODE'> = {
     command: '%XSYSTEMMODE',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/xsystemmode.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/mob_termination_ctrl_status/xsystemmode.html',
     initialState: () => ({}),
     onRequest: (packet, state) => {
         if (

--- a/src/features/tracingEvents/at/commandProcessors/xsim.ts
+++ b/src/features/tracingEvents/at/commandProcessors/xsim.ts
@@ -26,7 +26,7 @@ const cause = {
 export const processor: Processor<'%XSIM'> = {
     command: '%XSIM',
     documentation:
-        'https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/access_uicc/xsim.html',
+        'https://docs.nordicsemi.com/bundle/ref_at_commands/page/REF/at_commands/access_uicc/xsim.html',
     initialState: () => ({}),
     onResponse: (packet, state, requestType) => {
         if (requestType === RequestType.READ && packet.payload) {


### PR DESCRIPTION
Replaced Infocenter and developer doc links with TechDocs ones. Removed section about the Feedback tab.