### PR TITLE
modem_trace_snippet: fix docs and dialog

### DIFF
--- a/doc/docs/overview.md
+++ b/doc/docs/overview.md
@@ -30,7 +30,7 @@ Opens file explorer and allows you to select an `.mtrace` or `.bin` file. The se
 
 When a device is selected, Cellular Monitor tries to discover its capabilities. The side panel options are updated depending on the results.
 
-![Cellular Monitor application window after selecting a device](./screenshots/cel_mon_overview.png "Cellular Monitor application window after selecting a device")
+![Cellular Monitor application window after selecting a device](./screenshots/cel_mon_overview_selected.png "Cellular Monitor application window after selecting a device")
 
 ### Start
 
@@ -86,7 +86,7 @@ See [Using Wireshark](./wireshark.md) for more information.
 
 If toggled on, starting tracing will create a raw temporary trace file for storing a copy of the trace for future use. After you start tracing, the information about the file and its size appears under the toggle.
 
-![Tracing file size information](./screenshots/cel_mon_overview.png "Tracing file size information")
+![Tracing file size information](./screenshots/cel_mon_overview_file_info.png "Tracing file size information")
 
 Clicking the file name opens its location.
 

--- a/doc/docs/requirements.md
+++ b/doc/docs/requirements.md
@@ -18,7 +18,7 @@ Alternatively, make sure that your application matches the following requirement
 
   - The modem firmware must be at least version 1.3.3.
   - The application firmware must use nRF Connect SDK version v2.0.1 or higher. The latest version is recommended.
-  - The application must enable modem trace over Universal Asynchronous Receiver/Transmitter (UART) using snippets. This enables the `CONFIG_NRF_MODEM_LIB_TRACE` Kconfig option. See [nRF Connect SDK nRF91 modem tracing with UART backend using snippets](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/device_guides/working_with_nrf/nrf91/nrf9160.html#nrf91_modem_tracing_with_uart_backend_using_snippets) for more information.
+  - The application must enable modem trace over Universal Asynchronous Receiver/Transmitter (UART) using snippets. You can do this by [adding the `nrf91-modem-trace-uart` snippet to your application's build configuration](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/device_guides/nrf91/nrf91_snippet.html#nrf91_modem_tracing_with_uart_backend_using_snippets), as described in the nRF Connect SDK documentation.
   - Your application must also include Modem Shell, the AT Host library, or AT Shell. See the following for more information.
     - Enable the [AT Host](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/modem/at_host.html) library using the Kconfig option `CONFIG_AT_HOST_LIBRARY` in the `prj.conf` file of your application. The library exposes the AT commands interface to the application and enables you to communicate with the modem using AT commands.
     - Information on Modem Shell and AT Shell can be found in [nRF Connect SDK documentation](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html).

--- a/doc/docs/revision_history.md
+++ b/doc/docs/revision_history.md
@@ -1,7 +1,8 @@
 # Revision history
 
-| Date       | Description    |
-|------------|----------------|
-| 2024-02-26 | Minor documentation changes. |
-| 2024-01-12 | Updated documentation for the nRF Connect Cellular Monitor [v2.2.0](https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor/blob/main/Changelog.md). |
-| 2023-09-01 | First release. |
+|      Date      |                                                                            Description                                                                            |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| July 2024      | - Updated [software requirements](requirements.md#software-requirements) with information about the `nrf91-modem-trace-uart` snippet.</br>- Fixed incorrect images on the [overview page](overview.md).                                                                                                       |
+| February 2024  | Minor documentation changes.                                                                                                                                      |
+| January 2024   | Updated documentation for the nRF Connect Cellular Monitor [v2.2.0](https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor/blob/main/Changelog.md). |
+| September 2023 | First release.                                                                                                                                                    |

--- a/src/features/startup/startupDialog.tsx
+++ b/src/features/startup/startupDialog.tsx
@@ -13,7 +13,6 @@ import {
     Toggle,
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
-import Copy from '../../common/Copy';
 import {
     getShowStartupDialog,
     getShowStartupDialogOnAppStart,
@@ -22,11 +21,6 @@ import {
 } from './startupSlice';
 
 import './startupDialog.css';
-
-const Config = [
-    'CONFIG_NRF_MODEM_LIB_TRACE=y',
-    'CONFIG_AT_HOST_LIBRARY=y #(note this is optional)',
-];
 
 const StartupDialog = () => {
     const dispatch = useDispatch();
@@ -93,45 +87,32 @@ const StartupDialog = () => {
             }
         >
             <div style={{ padding: '32px' }}>
-                <b style={headerStyle}>
-                    Enable Trace in your application as follows:
-                </b>
+                <b style={headerStyle}>Enable Trace in your application</b>
                 <p>
-                    If you use nRF Connect SDK v2.0.1 or higher, add the
-                    following Kconfig snippets to enable trace, and optionally,
-                    AT commands in your application firmware.
+                    If you use nRF Connect SDK v2.0.1 or higher, your
+                    application must enable modem trace over Universal
+                    Asynchronous Receiver/Transmitter (UART) using snippets. You
+                    can do this by{' '}
+                    <a href="https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/device_guides/nrf91/nrf91_snippet.html#nrf91_modem_tracing_with_uart_backend_using_snippets">
+                        adding the `nrf91-modem-trace-uart` snippet to your
+                        build configuration
+                    </a>
+                    , as described in the nRF Connect SDK documentation.
                 </p>
-                <pre
-                    style={{
-                        whiteSpace: 'pre-wrap',
-                        userSelect: 'text',
-                        display: 'flex',
-                        alignItems: 'center',
-                    }}
-                >
-                    {Config.join('\n')}
-                    <Copy
-                        data={Config.join('\n')}
-                        size={0.9}
-                        style={{ marginLeft: '8px' }}
-                    />
-                </pre>
-
                 <p>
-                    Alternatively, in Advanced Options you can program a sample
+                    Alternatively, in <b>Advanced options</b> you can{' '}
+                    <a href="https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/overview.html#program-device">
+                        program a sample
+                    </a>
                     with trace enabled and upgrade your modem firmware.
                 </p>
 
                 <p>
-                    Minimum requirements:
-                    <ul>
-                        <li>
-                            A Nordic Semiconductor cellular device, such as an
-                            nRF91 series DK or Nordic Thingy:91™
-                        </li>
-                        <li>A nano SIM card supporting LTE-M or NB-IoT</li>
-                        <li>Modem firmware version 1.3.1 or higher</li>
-                    </ul>
+                    Check also{' '}
+                    <a href="https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/requirements.html">
+                        Cellular Monitor hardware and software requirements
+                    </a>
+                    .
                 </p>
             </div>
         </GenericDialog>


### PR DESCRIPTION
Fixed outdated information on the startup dialog and in the docs. NRFU-1011.