### PR TITLE
doc: rename app + other edits

### DIFF
--- a/.github/workflows/zoomin-publish.yml
+++ b/.github/workflows/zoomin-publish.yml
@@ -1,4 +1,4 @@
-name: Publish documentation to Zoomin
+name: Publish documentation to Zoomin prod
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -1,15 +1,22 @@
-# nRF Connect Cellular Monitor
+# Cellular Monitor app
 
 [![Build Status](https://dev.azure.com/NordicSemiconductor/Wayland/_apis/build/status/pc-nrfconnect-cellularmonitor?branchName=main)](https://dev.azure.com/NordicSemiconductor/Wayland/_build/latest?definitionId=153&branchName=main)
 [![License](https://img.shields.io/badge/license-Modified%20BSD%20License-blue.svg)](LICENSE)
 
-nRF Connect Cellular Monitor is a tool that enables you to capture and analyze
+The Cellular Monitor app in nRF Connect for Desktop lets you capture and analyze
 modem traces.
 
 ## Installation
 
+The Cellular Monitor app is installed from nRF Connect from Desktop. For detailed
+steps, see
+[Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html)
+in the nRF Connect from Desktop documentation.
+
+## Documentation
+
 Read the
-[nRF Connect Cellular Monitor](https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/index.html)
+[Cellular Monitor app](https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/index.html)
 official documentation.
 
 ## Development
@@ -26,7 +33,7 @@ Please report issues on the [DevZone](https://devzone.nordicsemi.com) portal.
 ## Contributing
 
 See the
-[infos on contributing](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/contributing)
+[information on contributing](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/contributing)
 for details.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ modem traces.
 
 ## Installation
 
-The Cellular Monitor app is installed from nRF Connect from Desktop. For detailed
-steps, see
+The Cellular Monitor app is installed from nRF Connect from Desktop. For
+detailed steps, see
 [Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html)
 in the nRF Connect from Desktop documentation.
 

--- a/doc/docs/capturing.md
+++ b/doc/docs/capturing.md
@@ -1,12 +1,12 @@
 # Capturing a modem trace
 
-Cellular Monitor generates a broad set of cellular environment data displayed in the [**Dashboard**](./overview.md#dashboard-tab) tab panels. Optionally, you can also view the modem trace in Wireshark and observe application logging and the modem dialog in [Serial Terminal](https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html).
+The {{app_name}} generates a broad set of cellular environment data displayed in the [**Dashboard**](./overview.md#dashboard-tab) tab panels. Optionally, you can also view the modem trace in Wireshark and observe application logging and the modem dialog in [Serial Terminal](https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html).
 
 See [Minimum requirements and limitations](./requirements.md) and [Preparing the device for modem trace](./preparing.md).
 
 Complete the following steps to trace data:
 
-1. Set the trace options in the Cellular Monitor side panel according to your needs. See [Overview and user interface](./overview.md) for the description of the available options.
+1. Set the trace options in the {{app_name}} side panel according to your needs. See [Overview and user interface](./overview.md) for the description of the available options.
 
 2. Click **Start** to trace.</br>
    Depending on the options you have chosen, the application starts tracing and applies the selected options. The initialization of tracing can take some time.
@@ -26,6 +26,6 @@ Complete the following steps to trace data:
      - **Long-Term Evolution (LTE) Connection** depends on conditions in the local cellular network to which you are subscribed.
      - **Packet Data Network (PDN)** turns green when the device has successfully connected to the connection endpoint.
 
-![Cellular Monitor tracing started](./screenshots/cel_mon_capture_started.png "Cellular Monitor tracing started")
+![{{app_name}}: tracing started](./screenshots/cel_mon_capture_started.png "{{app_name}}: tracing started")
 
-For more information on trace data visualization, see [Viewing a modem trace in Cellular Monitor](./viewing.md).
+For more information on trace data visualization, see [Viewing a modem trace in the {{app_name}}](./viewing.md).

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -1,10 +1,10 @@
-# nRF Connect Cellular Monitor
+# {{app_name}}
 
-nRF Connect for Desktop Cellular Monitor is a cross-platform tool for Nordic Semiconductor nRF91 Series devices. It is used for capturing and analyzing modem traces to evaluate communication and view network parameters.
+The {{app_name}} is a cross-platform tool for Nordic Semiconductor nRF91 Series devices. It is used for capturing and analyzing modem traces to evaluate communication and view network parameters.
 
-A cellular connection involves the interoperation of diverse components and scenarios. Sometimes not everything goes according to plan, and we need information about the environment. The modem of the nRF91 Series System in Package (SiP) collects data about the connection in a modem trace. With Cellular Monitor, you can access the trace data and use it to visualize and optimize the connection.
+A cellular connection involves the interoperation of diverse components and scenarios. Sometimes not everything goes according to plan, and we need information about the environment. The modem of the nRF91 Series System in Package (SiP) collects data about the connection in a modem trace. With the {{app_name}}, you can access the trace data and use it to visualize and optimize the connection.
 
-## Cellular Monitor features
+## {{app_name}} features
 
 - Get started quickly by programming precompiled sample apps and modem firmware to the device
 - Modem trace capture - live or playback modes
@@ -16,6 +16,6 @@ A cellular connection involves the interoperation of diverse components and scen
 - Play back trace files from Trace Collector, nRF Util Trace, Memfault, and Real Time Transfer (RTT)
 - Modem credential management
 
-Cellular Monitor replaces the deprecated nRF Connect for Desktop apps Trace Collector and LTE Link Monitor.
+The {{app_name}} replaces the deprecated nRF Connect for Desktop apps Trace Collector and LTE Link Monitor.
 
-Cellular Monitor is installed and updated using [nRF Connect for Desktop](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html).
+The {{app_name}} is installed and updated using [nRF Connect for Desktop](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html).

--- a/doc/docs/installing.md
+++ b/doc/docs/installing.md
@@ -1,3 +1,3 @@
-# Installing Cellular Monitor app
+# Installing the {{app_name}}
 
 For installation instructions, see [Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html) in the nRF Connect for Desktop documentation.

--- a/doc/docs/loading.md
+++ b/doc/docs/loading.md
@@ -1,15 +1,14 @@
-# Loading modem traces for play back
+# Loading modem traces for playback
 
-You can view previously collected traces in **Cellular Monitor**, including those captured in the **Trace Collector** app.
+You can view previously collected traces in the {{app_name}}, including those captured in the legacy Trace Collector app.
 
-Open Cellular Monitor
-
+1. Open the {{app_name}}.
 1. Click **Load trace file...** in the side panel.</br>
-   File explorer opens.
-2. Browse to the folder where you saved the trace. Select and double-click the file to open it.</br>
-   Cellular Monitor auto detects the modem firmware version from the trace file.
+   The file explorer opens.
+1. Browse to the folder where you saved the trace. Select and double-click the file to open it.</br>
+   The {{app_name}} auto detects the modem firmware version from the trace file.
    You can also select the modem trace database version from the dropdown list.
 
     ![The dashboard and UI are filled with the trace information](./screenshots/Cell_mon_playback_result.png "The dashboard and UI are filled with the trace information")
 
-See [Viewing a Modem trace in Cellular Monitor](./viewing.md) for more information.
+See [Viewing a Modem trace in the {{app_name}}](./viewing.md) for more information.

--- a/doc/docs/memfault_in_production.md
+++ b/doc/docs/memfault_in_production.md
@@ -1,6 +1,6 @@
 # Memfault and modem trace in production
 
-In a production environment, you can configure the application to send modem traces to Memfault. The trace files can be downloaded from Memfault for playback and analysis in Cellular Monitor.
+In a production environment, you can configure the application to send modem traces to Memfault. The trace files can be downloaded from Memfault for playback and analysis in the {{app_name}}.
 
 For information on nRF Connect SDK samples showing how to send modem traces to Memfault, see [Memfault configuration](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/debug/memfault_ncs.html#configuration) in the nRF Connect SDK documentation.
 

--- a/doc/docs/overview.md
+++ b/doc/docs/overview.md
@@ -1,8 +1,8 @@
 # Overview and user interface
 
-After starting Cellular Monitor, the main application window is displayed.
+After starting the {{app_name}}, the main application window is displayed.
 
-![Cellular Monitor application window](./screenshots/cel_mon_overview.png "Cellular Monitor application window")
+![{{app_name}} window](./screenshots/cel_mon_overview.png "{{app_name}} window")
 
 The available options and information change after you **Select Device**. If a supported device is selected, you can capture traces; otherwise, traces can be played back from a file.
 
@@ -20,7 +20,7 @@ Opens a dialog with localized links to partner websites to purchase the supporte
 
 ### Load trace file...
 
-Opens File Explorer and allows you to select a trace file. Traces captured using Cellular Monitor have the file extension `.mtrace`. You can also open files from `nrfutil trace` and `.bin` files from the legacy [nRF Connect Trace Collector](https://docs.nordicsemi.com/bundle/nrf-connect-tracecollector/page/index.html).
+Opens File Explorer and allows you to select a trace file. Traces captured using the {{app_name}} have the file extension `.mtrace`. You can also open files from `nrfutil trace` and `.bin` files from the legacy Trace Collector app.
 
 ### Open trace file in Wireshark...
 
@@ -28,9 +28,9 @@ Opens file explorer and allows you to select an `.mtrace` or `.bin` file. The se
 
 ## After selection
 
-When a device is selected, Cellular Monitor tries to discover its capabilities. The side panel options are updated depending on the results.
+When a device is selected, the {{app_name}} tries to discover its capabilities. The side panel options are updated depending on the results.
 
-![Cellular Monitor application window after selecting a device](./screenshots/cel_mon_overview.png "Cellular Monitor application window after selecting a device")
+![{{app_name}} window after selecting a device](./screenshots/cel_mon_overview.png "{{app_name}} window after selecting a device")
 
 ### Start
 
@@ -41,7 +41,7 @@ Starts tracing for the selected device.
 
 ### Refresh dashboard
 
-Extensively populates the dashboard fields by sending a set of recommended AT commands to your device. This button is available only if Cellular Monitor has identified either Modem Shell or [AT Host](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html) on the device, and if you started tracing.
+Extensively populates the dashboard fields by sending a set of recommended AT commands to your device. This button is available only if the {{app_name}} identified either Modem Shell or [AT Host](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html) on the device, and if you started tracing.
 
 You can toggle on [Refresh dashboard on start](#refresh-dashboard-on-start) so that this action is automatically run when the tracing starts.
 
@@ -49,7 +49,7 @@ When you start tracing, this button changes to **Sending commands** during the t
 
 ### Open Serial Terminal
 
-Opens the Serial Terminal application in a new window. You can view the modem dialog and logging information from your application and the RTOS here. Depending on the application running, you can also send custom AT commands. See [nRF Connect Serial Terminal](https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html) for more information on the application.
+Opens the Serial Terminal application in a new window. You can view the modem dialog and logging information from your application and the RTOS here. Depending on the application running, you can also send custom AT commands. See the [Serial Terminal app](https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html) for more information on the application.
 
 ### Connection Status
 
@@ -63,7 +63,7 @@ This section lists common tracing options.
 
 The trace database is used to decode the raw modem trace. Each modem firmware version has a separate trace database. The trace database version must match the modem firmware version of the selected device.
 
-If [AT Host](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html) is enabled, choose **Autoselect** to have Cellular Monitor automatically select the trace database version. If not, select the database whose version matches your modem firmware from the dropdown list of databases.
+If [AT Host](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html) is enabled, choose **Autoselect** to have the {{app_name}} automatically select the trace database version. If not, select the database whose version matches your modem firmware from the dropdown list of databases.
 
 #### Modem trace serial port
 
@@ -96,7 +96,7 @@ This section lists advanced tracing options.
 
 #### Program device
 
-Select and program precompiled sample applications and modem firmware to your device. The samples enable the trace and [AT Host](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html) prerequisites for Cellular Monitor. Modem firmware supporting trace is available with all samples, and you can choose to program the modem firmware or the application firmware, or both. The modem firmware needs only to be programmed once.
+Select and program precompiled sample applications and modem firmware to your device. The samples enable the trace and [AT Host](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html) prerequisites for the {{app_name}}. Modem firmware supporting trace is available with all samples, and you can choose to program the modem firmware or the application firmware, or both. The modem firmware needs only to be programmed once.
 
 !!! note "Note"
      Programming the modem firmware deletes the application firmware. If you choose to program only the modem firmware, you need to reprogram the application firmware.
@@ -108,12 +108,12 @@ The serial port used to send AT commands to your device if Modem Shell or [AT Ho
 ## Dashboard tab
 
 The dashboard contains detailed information about the connection and its components. During trace, dashboard fields are highlighted as they are populated.
-See [Viewing a Modem trace in Cellular Monitor](./viewing.md) for more information.
+See [Viewing a Modem trace in the {{app_name}}](./viewing.md) for more information.
 
 ### Packet Event Viewer
 
 The **Packet Event Viewer** visualizes communication at the AT command, Radio Resource Control (RRC), Non-access Stratum (NAS), and Internet Protocol (IP) levels.
-See [Viewing a Modem trace in Cellular Monitor](./viewing.md) for more information.
+See [Viewing a Modem trace in the {{app_name}}](./viewing.md) for more information.
 
 ## Certificate Manager tab
 

--- a/doc/docs/preparing.md
+++ b/doc/docs/preparing.md
@@ -8,6 +8,6 @@ A device can optionally be programmed with modem trace prerequisites, making it 
 3. Select the device you want to use.</br>
     The options in the left-side panel are updated. See [Overview and user interface](./overview.md).
 
-    You can also view information on the device's connection settings and status in the Cellular Monitor **Log** view.
+    You can also view information on the device's connection settings and status in the {{app_name}}'s **Log** view.
 
-4. If your application does not support Cellular Monitor minimum requirements, use the [**Program device**](./overview.md#program-device) button to program the prerequisites.
+4. If your application does not support the {{app_name}} minimum requirements, use the [**Program device**](./overview.md#program-device) button to program the prerequisites.

--- a/doc/docs/preparing.md
+++ b/doc/docs/preparing.md
@@ -8,6 +8,6 @@ A device can optionally be programmed with modem trace prerequisites, making it 
 3. Select the device you want to use.</br>
     The options in the left-side panel are updated. See [Overview and user interface](./overview.md).
 
-    You can also view information on the device's connection settings and status in the {{app_name}}'s **Log** view.
+    You can also view information on the device's connection settings and status in the **Log** view.
 
 4. If your application does not support the {{app_name}} minimum requirements, use the [**Program device**](./overview.md#program-device) button to program the prerequisites.

--- a/doc/docs/requirements.md
+++ b/doc/docs/requirements.md
@@ -1,6 +1,6 @@
 # Minimum requirements and limitations
 
-Cellular Monitor supports the following Development Kits (DKs) and prototyping platforms for cellular development:
+The {{app_name}} supports the following Development Kits (DKs) and prototyping platforms for cellular development:
 
 - nRF91 Series DK
 - Nordic Thingy:91™
@@ -8,7 +8,7 @@ Cellular Monitor supports the following Development Kits (DKs) and prototyping p
 
 Additionally, you might need the following:
 
-- If you are using an nRF91 Series DK or a custom board, you also need a USB cable to you Cellular Monitor.
+- If you are using an nRF91 Series DK or a custom board, you also need a USB cable.
 - If you are using a DK or platform that requires a physical SIM card, you also need a SIM card supporting LTE-M or NB-IoT.
 
 ## Software requirements
@@ -18,7 +18,7 @@ Alternatively, make sure that your application matches the following requirement
 
   - The modem firmware must be at least version 1.3.3.
   - The application firmware must use nRF Connect SDK version v2.0.1 or higher. The latest version is recommended.
-  - The application must enable modem trace over Universal Asynchronous Receiver/Transmitter (UART) using snippets. This enables the `CONFIG_NRF_MODEM_LIB_TRACE` Kconfig option. See [nRF Connect SDK nRF91 modem tracing with UART backend using snippets](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/device_guides/working_with_nrf/nrf91/nrf9160.html#nrf91_modem_tracing_with_uart_backend_using_snippets) for more information.
+  - The application must enable modem trace over Universal Asynchronous Receiver/Transmitter (UART) using snippets. This enables the `CONFIG_NRF_MODEM_LIB_TRACE` Kconfig option. See [nRF91 modem tracing with UART backend using snippets](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/device_guides/nrf91/nrf91_snippet.html#nrf91_modem_tracing_with_uart_backend_using_snippets) in the nRF Connect SDK documentation for more information.
   - Your application must also include Modem Shell, the AT Host library, or AT Shell. See the following for more information.
     - Enable the [AT Host](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/modem/at_host.html) library using the Kconfig option `CONFIG_AT_HOST_LIBRARY` in the `prj.conf` file of your application. The library exposes the AT commands interface to the application and enables you to communicate with the modem using AT commands.
     - Information on Modem Shell and AT Shell can be found in [nRF Connect SDK documentation](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html).
@@ -27,4 +27,4 @@ Alternatively, make sure that your application matches the following requirement
 
 Some limitations apply for applications that do not use AT commands extensively.
 
-In the first release of Cellular Monitor, the information in the **Dashboard** tab and in the **Connection Status** section are based on the AT commands in the modem trace. This limits trace data for applications that do not extensively use AT. It is recommended to use the option **Open in Wireshark** where you can find all available traffic.
+In the first release of the {{app_name}}, the information in the **Dashboard** tab and in the **Connection Status** section are based on the AT commands in the modem trace. This limits trace data for applications that do not extensively use AT. It is recommended to use the option **Open in Wireshark** where you can find all available traffic.

--- a/doc/docs/revision_history.md
+++ b/doc/docs/revision_history.md
@@ -2,6 +2,7 @@
 
 | Date       | Description    |
 |------------|----------------|
-| 2024-02-26 | Minor documentation changes. |
-| 2024-01-12 | Updated documentation for the nRF Connect Cellular Monitor [v2.2.0](https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor/blob/main/Changelog.md). |
-| 2023-09-01 | First release. |
+| November 2024 | Editorial changes. |
+| February 2024 | Minor documentation changes. |
+| January 2024 | Updated documentation for the {{app_name}} [v2.2.0](https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor/blob/main/Changelog.md). |
+| September 2023 | First release. |

--- a/doc/docs/troubleshooting.md
+++ b/doc/docs/troubleshooting.md
@@ -2,7 +2,7 @@
 
 These troubleshooting instructions can help you fix issues you might encounter in the {{app_name}}.
 
-Check the {{app_name}}'s [Minimum requirements and limitations](./requirements.md).
+Check the app's [Minimum requirements and limitations](./requirements.md).
 
 ## Trace data is not displayed or the file size does not increase
   - Check the trace serial port used.
@@ -24,7 +24,7 @@ Check the {{app_name}}'s [Minimum requirements and limitations](./requirements.m
 
 Make sure that **Save trace file to disk** is enabled before starting the trace if you want them to be saved. The easiest way to find your saved files is to click **Load trace file**.
 
-The {{app_name}}'s `.mtrace` files are binary files. The `.mtrace` file extension is used to separate them from other binary files (extension `.bin`). If you want to open the file in a tool that requires a `.bin` extension, replace the `.mtrace` extension with a `.bin`. You are still able to open it in the {{app_name}}.
+The `.mtrace` files are binary files. The `.mtrace` file extension is used to separate them from other binary files (extension `.bin`). If you want to open the file in a tool that requires a `.bin` extension, replace the `.mtrace` extension with a `.bin`. You are still able to open it in the {{app_name}}.
 
 ## Is it sufficient to update `prj.conf` to enable modem trace?
 

--- a/doc/docs/troubleshooting.md
+++ b/doc/docs/troubleshooting.md
@@ -1,8 +1,8 @@
 # Troubleshooting
 
-These troubleshooting instructions can help you fix issues you might encounter in Cellular Monitor.
+These troubleshooting instructions can help you fix issues you might encounter in the {{app_name}}.
 
-Check Cellular Monitor's [Minimum requirements and limitations](./requirements.md).
+Check the {{app_name}}'s [Minimum requirements and limitations](./requirements.md).
 
 ## Trace data is not displayed or the file size does not increase
   - Check the trace serial port used.
@@ -24,8 +24,8 @@ Check Cellular Monitor's [Minimum requirements and limitations](./requirements.m
 
 Make sure that **Save trace file to disk** is enabled before starting the trace if you want them to be saved. The easiest way to find your saved files is to click **Load trace file**.
 
-Cellular Monitor `.mtrace` files are binary files. The `.mtrace` file extension is used to separate them from other binary files (extension `.bin`). If you want to open the file in a tool that requires a `.bin` extension, replace the `.mtrace` extension with a `.bin`. You are still able to open it in Cellular Monitor.
+The {{app_name}}'s `.mtrace` files are binary files. The `.mtrace` file extension is used to separate them from other binary files (extension `.bin`). If you want to open the file in a tool that requires a `.bin` extension, replace the `.mtrace` extension with a `.bin`. You are still able to open it in the {{app_name}}.
 
 ## Is it sufficient to update `prj.conf` to enable modem trace?
 
-No, the latest UART trace backend requires changes to the device tree, as well as the configuration. It is recommended to use the new backend and snippets, see [nRF Connect SDK nRF91 modem tracing with UART backend using snippets](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/device_guides/working_with_nrf/nrf91/nrf9160.html#nrf91_modem_tracing_with_uart_backend_using_snippets) for more information.
+No, the latest UART trace backend requires changes to the device tree, as well as the configuration. It is recommended to use the new backend and snippets, see [nRF91 modem tracing with UART backend using snippets](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/device_guides/working_with_nrf/nrf91/nrf9160.html#nrf91_modem_tracing_with_uart_backend_using_snippets) in the nRF Connect SDK documentation for more information.

--- a/doc/docs/viewing.md
+++ b/doc/docs/viewing.md
@@ -1,6 +1,6 @@
-# Viewing a modem trace in Cellular Monitor
+# Viewing a modem trace in the {{app_name}}
 
-To play back and focus on a part of the trace, you can drag and scroll the **Packet Event Viewer**. Cellular Monitor's [**Connection Status**](./overview.md#connection-status) and [**Dashboard**](./overview.md#dashboard-tab) update accordingly and replay the selected events.
+To play back and focus on a part of the trace, you can drag and scroll the **Packet Event Viewer**. The {{app_names}}'s [**Connection Status**](./overview.md#connection-status) and [**Dashboard**](./overview.md#dashboard-tab) update accordingly and replay the selected events.
 
 ## Packet Event Viewer
 

--- a/doc/docs/viewing.md
+++ b/doc/docs/viewing.md
@@ -1,6 +1,6 @@
 # Viewing a modem trace in the {{app_name}}
 
-To play back and focus on a part of the trace, you can drag and scroll the **Packet Event Viewer**. The {{app_names}}'s [**Connection Status**](./overview.md#connection-status) and [**Dashboard**](./overview.md#dashboard-tab) update accordingly and replay the selected events.
+To play back and focus on a part of the trace, you can drag and scroll the **Packet Event Viewer**. The [**Connection Status**](./overview.md#connection-status) and [**Dashboard**](./overview.md#dashboard-tab) update accordingly and replay the selected events.
 
 ## Packet Event Viewer
 

--- a/doc/docs/viewing_rtt.md
+++ b/doc/docs/viewing_rtt.md
@@ -1,9 +1,9 @@
 # Viewing RTT modem traces
 
-Modem traces captured in J-Link Real Time Transfer (RTT) logger can be played back in Cellular Monitor.
+Modem traces captured in J-Link Real Time Transfer (RTT) logger can be played back in the {{app_name}}.
 
 !!! note "Note"
-      In the current release of Cellular Monitor, the RTT interface is not supported for traces capture. You can only view RTT modem traces captured outside of the tool.
+      In the current release of the {{app_name}}, the RTT interface is not supported for traces capture. You can only view RTT modem traces captured outside of the tool.
 
 To view RTT modem traces captured outside of the tool in Cellular Monitor, complete the following steps:
 

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: nRF Connect Cellular Monitor documentation
+site_name: Cellular Monitor app documentation
 site_url:
 use_directory_urls: false
 
@@ -42,9 +42,6 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.tabbed
   - pymdownx.superfences
-  - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
   - toc:
       permalink: true
       toc_depth: 4
@@ -56,15 +53,16 @@ plugins:
 
 extra:
   test: This is a test abbreviation snippet
+  app_name: Cellular Monitor app
 
 nav:
   - Home: index.md
-  - Installing Cellular Monitor app: installing.md
+  - Installing the Cellular Monitor app: installing.md
   - Minimum requirements and limitations: requirements.md
   - Overview and user interface: overview.md
   - Preparing the device for modem trace: preparing.md
   - Capturing a modem trace: capturing.md
-  - Viewing a modem trace in Cellular Monitor: viewing.md
+  - Viewing a modem trace in the Cellular Monitor app: viewing.md
   - Using Wireshark: wireshark.md
   - Loading modem traces for play back: loading.md
   - Viewing RTT modem traces: viewing_rtt.md

--- a/doc/zoomin/custom.properties
+++ b/doc/zoomin/custom.properties
@@ -1,3 +1,3 @@
 manual.name=nrf-connect-cellularmonitor
-booktitle=nRF Connect Cellular Monitor
-shortdesc=Documentation for the nRF Connect Cellular Monitor application.
+booktitle=Cellular Monitor app
+shortdesc=Documentation for the Cellular Monitor application.


### PR DESCRIPTION
Dropped nRF Connect from app name.
Updated copyright year.
Removed unused extensions.
Added app_name abbreviation.
NCD-1066.