### PR TITLE
Certificate manager tab fixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,13 +1,9 @@
 ## 2.4.3 - unreleased
 
-### Changed
-
--   UI layout fixes for the certificate manager tab.
-
 ### Fixed
 
--   Security tag in the certificate manager form could become uneditable when
-    non-numeric value was passed.
+-   Issues with the UI layout in the **Certificate Manager** tab.
+-   Issue with editing the security tag in the **Certificate Manager** tab, which would cause the form to freeze when a non-numeric value was passed.
 
 ## 2.4.2 - 2024-11-11
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,9 @@
 ### Fixed
 
 -   Issues with the UI layout in the **Certificate Manager** tab.
--   Issue with editing the security tag in the **Certificate Manager** tab, which would cause the input to become uneditable when a non-numeric value was passed.
+-   Issue with editing the security tag in the **Certificate Manager** tab,
+    which would cause the input to become uneditable when a non-numeric value
+    was passed.
 
 ## 2.4.2 - 2024-11-11
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,12 @@
 
 ### Changed
 
--   Minor UI layout fixes.
+-   UI layout fixes for the certificate manager tab.
+
+### Fixed
+
+-   Security tag in the certificate manager form could become uneditable when
+    non-numeric value was passed.
 
 ## 2.4.2 - 2024-11-11
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ### Fixed
 
 -   Issues with the UI layout in the **Certificate Manager** tab.
--   Issue with editing the security tag in the **Certificate Manager** tab, which would cause the form to freeze when a non-numeric value was passed.
+-   Issue with editing the security tag in the **Certificate Manager** tab, which would cause the input to become uneditable when a non-numeric value was passed.
 
 ## 2.4.2 - 2024-11-11
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## 2.4.3 - unreleased
+
+### Changed
+
+-   Minor UI layout fixes.
+
 ## 2.4.2 - 2024-11-11
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-cellularmonitor",
-    "version": "2.4.2",
+    "version": "2.4.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-cellularmonitor",
-    "version": "2.4.2",
+    "version": "2.4.3",
     "description": "Capture and analyze modem traces",
     "displayName": "Cellular Monitor",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor",

--- a/src/features/certificateManager/CertificateManager.tsx
+++ b/src/features/certificateManager/CertificateManager.tsx
@@ -248,7 +248,7 @@ export default ({ active }: { active: boolean }) => {
                     Cloud certificate, otherwise pick a different tag.
                 </div>
             </Alert>
-            <Form className="mb-4 mt-4 pr-4">
+            <div className="mb-4 mt-4 pr-4">
                 <div className="tw-grid tw-grid-cols-3 tw-gap-4">
                     <div className="tw-col-span-3 lg:tw-col-span-2">
                         {FormGroupWithCheckbox({
@@ -322,7 +322,7 @@ export default ({ active }: { active: boolean }) => {
                         </Form.Group>
                     </div>
                 </div>
-            </Form>
+            </div>
             <ButtonGroup className="align-self-end">
                 <Button
                     variant="secondary"

--- a/src/features/certificateManager/CertificateManager.tsx
+++ b/src/features/certificateManager/CertificateManager.tsx
@@ -231,7 +231,7 @@ export default ({ active }: { active: boolean }) => {
     return (
         <div className={`${className} ${active ? 'hidden' : ''}`}>
             <Alert variant="info">
-                <span className="h-100 mdi mdi-information mdi-36px float-left pr-3" />
+                <span className="mdi mdi-information mdi-36px float-left pr-3" />
                 <div style={{ lineHeight: '1.5rem', userSelect: 'text' }}>
                     The modem must be in <strong>offline</strong> state (
                     <code>AT+CFUN=4</code>) for updating certificates.

--- a/src/features/certificateManager/CertificateManager.tsx
+++ b/src/features/certificateManager/CertificateManager.tsx
@@ -220,7 +220,7 @@ export default ({ active }: { active: boolean }) => {
     };
 
     const className =
-        'cert-mgr-view d-flex flex-column p-4 h-100 overflow-auto pretty-scrollbar';
+        'd-flex flex-column p-4 h-100 tw-overflow-y-scroll styled-scroll';
     const textAreaProps = {
         as: 'textarea',
         className: 'text-monospace',
@@ -311,9 +311,12 @@ export default ({ active }: { active: boolean }) => {
                                 <Form.Control
                                     type="text"
                                     value={secTag}
-                                    onChange={({ target }) =>
-                                        setSecTag(Number(target.value))
-                                    }
+                                    onChange={({ target }) => {
+                                        const tag = Number(target.value);
+                                        if (Number.isNaN(tag)) return;
+
+                                        setSecTag(tag);
+                                    }}
                                 />
                             </Col>
                         </Form.Group>

--- a/src/features/certificateManager/CertificateManager.tsx
+++ b/src/features/certificateManager/CertificateManager.tsx
@@ -249,8 +249,8 @@ export default ({ active }: { active: boolean }) => {
                 </div>
             </Alert>
             <Form className="mb-4 mt-4 pr-4">
-                <Row>
-                    <Col xs={8}>
+                <div className="tw-grid tw-grid-cols-3 tw-gap-4">
+                    <div className="tw-col-span-3 lg:tw-col-span-2">
                         {FormGroupWithCheckbox({
                             controlId: 'certMgr.caCert',
                             controlProps: textAreaProps,
@@ -279,8 +279,8 @@ export default ({ active }: { active: boolean }) => {
                             clear: clearPrivateKey,
                             setClear: setClearPrivateKey,
                         })}
-                    </Col>
-                    <Col xs={4}>
+                    </div>
+                    <div className="tw-col-span-3 lg:tw-col-span-1">
                         {FormGroupWithCheckbox({
                             controlId: 'certMgr.preSharedKey',
                             controlProps: textProps,
@@ -317,8 +317,8 @@ export default ({ active }: { active: boolean }) => {
                                 />
                             </Col>
                         </Form.Group>
-                    </Col>
-                </Row>
+                    </div>
+                </div>
             </Form>
             <ButtonGroup className="align-self-end">
                 <Button

--- a/src/index.scss
+++ b/src/index.scss
@@ -42,3 +42,7 @@
 body {
     overflow: hidden;
 }
+
+.styled-scroll {
+    @include scrollbars($gray-100);
+}


### PR DESCRIPTION
**Before vs After:**

**1)**
<img width="1533" alt="image" src="https://github.com/user-attachments/assets/b3059a59-1e72-4d1c-adc8-ef552057d5c5">

**2)**
<img width="981" alt="image" src="https://github.com/user-attachments/assets/ce3af7df-03c7-4afd-9ec9-ac516c07d726">

**3)**
<img width="1520" alt="image" src="https://github.com/user-attachments/assets/f53d9bd3-3671-49d1-958b-46ea9102f39d">

**4) Before**
<img width="1210" alt="image" src="https://github.com/user-attachments/assets/7f26c29b-4b65-4140-8ac4-353f159525ef">

**4) After**
<img width="1210" alt="image" src="https://github.com/user-attachments/assets/4c105401-d354-4437-a97b-cb1fda99cdb5">

Note: not sure that wrapping text in the info alert is an issue, for smaller window dimentions can be considered as a feature, so please comment on this if you disagree with the change