### PR TITLE
Use files.nordicsemi.com for file downloads

### DIFF
--- a/src/features/programSample/samples.ts
+++ b/src/features/programSample/samples.ts
@@ -39,7 +39,7 @@ export interface Samples {
 }
 
 const SERVER_URL =
-    'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/samples';
+    'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=true&repoKey=swtools&path=external/ncd/cellular-monitor/samples';
 const DOWNLOAD_FOLDER = join(getAppDataDir(), 'firmware');
 
 const fullPath = (file: string) =>

--- a/src/features/tracing/traceDatabase.ts
+++ b/src/features/tracing/traceDatabase.ts
@@ -38,7 +38,7 @@ export type DatabaseVersion = {
 };
 
 const SERVER_URL =
-    'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/trace-db';
+    'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=true&repoKey=swtools&path=external/ncd/cellular-monitor/trace-db';
 const DOWNLOAD_FOLDER = join(getAppDataDir(), 'trace-db');
 const INITIAL_SOURCE_FOLDER = autoDetectDbRootFolder();
 


### PR DESCRIPTION
Because there are redirects in place for the old download locations, it is not critical to update this. However it is nice to point to the right location and it avoids using those redirects.