### PR TITLE
doc: custom board clarifications

### DIFF
--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -13,10 +13,13 @@ A cellular connection involves the interoperation of diverse components and scen
 - Packet event viewer
 - Extensive modem connection status dashboard with mouse-over access to detailed information
 - Auto-selection of trace database
-- Play back trace files from Trace Collector, nRF Util Trace, Memfault, and Real Time Transfer (RTT)
+- Play back trace files from Trace Collector, nRF Util's [`trace` command](https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-trace/guides/tracing.html), Memfault, and Real Time Transfer (RTT)
 - Modem credential management
 
-The {{app_name}} replaces the deprecated nRF Connect for Desktop apps Trace Collector and LTE Link Monitor.
+!!! note "Note"
+
+    The {{app_name}} replaces the deprecated nRF Connect for Desktop apps Trace Collector and LTE Link Monitor.
+    You can still play back trace files created with these legacy apps.
 
 The {{app_name}} is installed and updated using [nRF Connect for Desktop](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html).
 

--- a/doc/docs/overview.md
+++ b/doc/docs/overview.md
@@ -20,7 +20,7 @@ Opens a dialog with localized links to partner websites to purchase the supporte
 
 ### Load trace file...
 
-Opens File Explorer and allows you to select a trace file. Traces captured using the {{app_name}} have the file extension `.mtrace`. You can also open files from `nrfutil trace` and `.bin` files from the legacy Trace Collector app.
+Opens File Explorer and allows you to select a trace file. Traces captured using the {{app_name}} have the file extension `.mtrace`. You can also open files from [`nrfutil trace`](https://docs.nordicsemi.com/bundle/nrfutil/page/nrfutil-trace/guides/tracing.html) and `.bin` files from the legacy Trace Collector app.
 
 ### Open trace file in Wireshark...
 
@@ -96,9 +96,12 @@ This section lists advanced tracing options.
 
 #### Program device
 
+!!! note "Note"
+     This option is only available for the nRF9160 DK and Nordic Thingy:91™.
+
 Select and program precompiled sample applications and modem firmware to your device. The samples enable the trace and [AT Host](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html) prerequisites for the {{app_name}}. Modem firmware supporting trace is available with all samples, and you can choose to program the modem firmware or the application firmware, or both. The modem firmware needs only to be programmed once.
 
-!!! note "Note"
+!!! warning "Caution"
      Programming the modem firmware deletes the application firmware. If you choose to program only the modem firmware, you need to reprogram the application firmware.
 
 #### Terminal serial port

--- a/doc/docs/preparing.md
+++ b/doc/docs/preparing.md
@@ -10,4 +10,4 @@ A device can optionally be programmed with modem trace prerequisites, making it 
 
     You can also view information on the device's connection settings and status in the **Log** view.
 
-4. If your application does not support the {{app_name}} minimum requirements, use the [**Program device**](./overview.md#program-device) button to program the prerequisites.
+4. If your application does not support the {{app_name}}'s minimal requirements yet, program the required firmare as listed in [software requirements](requirements.md#software-requirements).

--- a/doc/docs/requirements.md
+++ b/doc/docs/requirements.md
@@ -23,7 +23,7 @@ Alternatively, for all other compatible devices (including custom boards), make 
   - The modem firmware must be at least version 1.3.3.
   - The application firmware must use nRF Connect SDK version v2.0.1 or higher. The latest version is recommended.
   - The application must enable modem trace over Universal Asynchronous Receiver/Transmitter (UART) using snippets. You can do this by [adding the `nrf91-modem-trace-uart` snippet to your application's build configuration](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/device_guides/nrf91/nrf91_snippet.html#nrf91_modem_tracing_with_uart_backend_using_snippets), as described in the nRF Connect SDK documentation.
-  - Your application must also include the following components from the nRF Connect SDK:
+  - Your application must also include one of the following components from the nRF Connect SDK:
 
      - [Modem Shell](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/cellular/modem_shell/README.html)
      - [AT Host](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/modem/at_host.html) library

--- a/doc/docs/requirements.md
+++ b/doc/docs/requirements.md
@@ -4,6 +4,7 @@ The {{app_name}} supports the following Development Kits (DKs) and prototyping p
 
 - nRF91 Series DK
 - Nordic Thingy:91™
+- Nordic Thingy:91 X™
 - Custom boards with an nRF91 Series System in Package (SiP)
 
 Additionally, you might need the following:
@@ -13,15 +14,26 @@ Additionally, you might need the following:
 
 ## Software requirements
 
-Your application or sample must enable modem trace and AT commands. **Program** one of the built-in sample apps or required modem firmware (or both).
-Alternatively, make sure that your application matches the following requirements:
+Your application or sample must enable modem trace and AT commands.
+
+If you are using the nRF9160 DK or Nordic Thingy:91™, you can [**Program device**](./overview.md#program-device) with one of the built-in sample apps or required modem firmware (or both).
+
+Alternatively, for all other compatible devices (including custom boards), make sure that your application matches the following requirements:
 
   - The modem firmware must be at least version 1.3.3.
   - The application firmware must use nRF Connect SDK version v2.0.1 or higher. The latest version is recommended.
   - The application must enable modem trace over Universal Asynchronous Receiver/Transmitter (UART) using snippets. You can do this by [adding the `nrf91-modem-trace-uart` snippet to your application's build configuration](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/device_guides/nrf91/nrf91_snippet.html#nrf91_modem_tracing_with_uart_backend_using_snippets), as described in the nRF Connect SDK documentation.
-  - Your application must also include Modem Shell, the AT Host library, or AT Shell. See the following for more information.
-    - Enable the [AT Host](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/modem/at_host.html) library using the Kconfig option `CONFIG_AT_HOST_LIBRARY` in the `prj.conf` file of your application. The library exposes the AT commands interface to the application and enables you to communicate with the modem using AT commands.
-    - Information on Modem Shell and AT Shell can be found in [nRF Connect SDK documentation](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html).
+  - Your application must also include the following components from the nRF Connect SDK:
+
+     - [Modem Shell](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/cellular/modem_shell/README.html)
+     - [AT Host](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/modem/at_host.html) library
+
+        - Enable the library using the Kconfig option `CONFIG_AT_HOST_LIBRARY` in the `prj.conf` file of your application. The library exposes the AT commands interface to the application and enables you to communicate with the modem using AT commands.
+
+     - [AT Shell](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/modem/at_shell.html)
+
+!!! info "Tip"
+      You can use the [Quick Start app](https://docs.nordicsemi.com/bundle/nrf-connect-quickstart/page/index.html) to install some of the required components from the nRF Connect SDK.
 
 ## Limitations
 

--- a/doc/docs/revision_history.md
+++ b/doc/docs/revision_history.md
@@ -2,9 +2,10 @@
 
 | Date       | Description    |
 |------------|----------------|
+| May 2025   | - Added Nordic Thingy:91 X™ to the list of devices in [Minimum requirements and limitations](./requirements.md).<br/>- Updated  [software requirements](requirements.md#software-requirements) with additional information for clarity (no new software requirements were added).<br/>- Updated information about **Program device** in [Overview and user interface](overview.md#program-device) and [Troubleshooting](./troubleshooting.md#i-do-not-see-program-device). |
 | January 2025   | Added the [Application source code](./index.md#application-source-code) section on the [Home](./index.md) page |
 | November 2024 | Editorial changes. |
-| July 2024      | - Updated [software requirements](requirements.md#software-requirements) with information about the `nrf91-modem-trace-uart` snippet.</br>- Fixed incorrect images on the [overview page](overview.md).                                                                                                       |
+| July 2024      | - Updated [software requirements](requirements.md#software-requirements) with information about the `nrf91-modem-trace-uart` snippet.<br/>- Fixed incorrect images on the [overview page](overview.md).                                                                                                       |
 | February 2024 | Minor documentation changes. |
 | January 2024 | Updated documentation for the {{app_name}} [v2.2.0](https://github.com/NordicSemiconductor/pc-nrfconnect-cellularmonitor/blob/main/Changelog.md). |
 | September 2023 | First release. |

--- a/doc/docs/troubleshooting.md
+++ b/doc/docs/troubleshooting.md
@@ -4,6 +4,11 @@ These troubleshooting instructions can help you fix issues you might encounter i
 
 Check the app's [Minimum requirements and limitations](./requirements.md).
 
+## I do not see **Program device**
+
+Check if you are using one of the [supported devices](requirements.md).
+The [**Program device**](overview.md#program-device) is only visible when using the nRF9160 DK or Nordic Thingy:91™.
+
 ## Trace data is not displayed or the file size does not increase
   - Check the trace serial port used.
 


### PR DESCRIPTION
Added information about Program device only visible for
the nRF9160 DK and Nordic Thingy:91.
Edited the requirements section.
Made corresponding changes on other pages.
NCD-1364.