### PR TITLE
doc: serial terminal at commands

### DIFF
--- a/doc/docs/capturing.md
+++ b/doc/docs/capturing.md
@@ -14,7 +14,7 @@ Complete the following steps to trace data:
 3. Generate additional trace data.
 
     - Click **Refresh dashboard** to send a set of AT commands to the device to feed the trace with information on the environment.
-    - Send AT commands using the Serial Terminal and from the dashboard fields.
+    - [Send AT commands using the Serial Terminal](https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/viewing_and_sending_at_commands.html) and from the dashboard fields.
 
 4. Follow the progress in the [**Connection Status**](./overview.md#connection-status) side panel.</br>
    On success, the stage's status indicator turns green with a checkmark.

--- a/doc/docs/overview.md
+++ b/doc/docs/overview.md
@@ -49,7 +49,7 @@ When you start tracing, this button changes to **Sending commands** during the t
 
 ### Open Serial Terminal
 
-Opens the Serial Terminal application in a new window. You can view the modem dialog and logging information from your application and the RTOS here. Depending on the application running, you can also send custom AT commands. See the [Serial Terminal app](https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html) for more information on the application.
+Opens the Serial Terminal application in a new window. You can view the modem dialog and logging information from your application and the RTOS here. Depending on the application running, you can also [send AT commands](https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/viewing_and_sending_at_commands.html). See the [Serial Terminal app](https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html) for more information on the application.
 
 ### Connection Status
 


### PR DESCRIPTION
Added links to the new page about AT commands
in the Serial Terminal docs. NCD-877.

----

First publish https://github.com/NordicSemiconductor/pc-nrfconnect-serial-terminal/pull/169