### PR TITLE
Update documentation links

### DIFF
--- a/src/app/DocumentationSection.tsx
+++ b/src/app/DocumentationSection.tsx
@@ -13,7 +13,7 @@ const DocumentationSections = [
     <DocumentationSection
         key="infocenter"
         linkLabel="Go to TechDocs"
-        link="https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/index.html"
+        link="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-cellularmonitor/index.html"
     >
         Visit our Technical Documentation for more documentation about using the
         app.
@@ -21,7 +21,7 @@ const DocumentationSections = [
     <DocumentationSection
         key="credentialManager"
         linkLabel="Certificate Manager"
-        link="https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/managing_credentials.html"
+        link="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-cellularmonitor/managing_credentials.html"
     >
         Visit our Technical Documentation for more documentation about managing
         credentials.

--- a/src/features/startup/startupDialog.tsx
+++ b/src/features/startup/startupDialog.tsx
@@ -108,7 +108,7 @@ const StartupDialog = () => {
                     <a
                         target="_blank"
                         rel="noreferrer"
-                        href="https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/overview.html#program-device"
+                        href="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-cellularmonitor/overview.html#program-device"
                     >
                         program a sample
                     </a>{' '}
@@ -120,7 +120,7 @@ const StartupDialog = () => {
                     <a
                         target="_blank"
                         rel="noreferrer"
-                        href="https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/requirements.html"
+                        href="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-cellularmonitor/index.html#minimum-requirements-and-limitations"
                     >
                         Cellular Monitor hardware and software requirements
                     </a>


### PR DESCRIPTION
https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor is the outdated bundle which is not updated anymore. Correct is now to link to https://docs.nordicsemi.com/bundle/swtools_docs.